### PR TITLE
12 twitchcontroller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.env*
 !/.env*.erb
 
+# Ignore app/.env file
+/app/.env
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/.env
+++ b/app/.env
@@ -1,2 +1,0 @@
-TWITCH_CLIENT_ID=ekrwi23agdtbnbi89k7034momvlit7
-TWITCH_CLIENT_SECRET=u1xrql54bjt8qn1slhn0go0u4c0sil

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,16 +1,16 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # CSRFトークンの検証をスキップ（必要に応じて）
-  skip_before_action :verify_authenticity_token, only: [:twitch]
+  skip_before_action :verify_authenticity_token, only: [ :twitch ]
 
   def twitch
     # OmniAuthから認証情報を取得
-    @user = User.from_omniauth(request.env['omniauth.auth'])
+    @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, kind: 'Twitch') if is_navigational_format?
+      set_flash_message(:notice, :success, kind: "Twitch") if is_navigational_format?
     else
-      session['devise.twitch_data'] = request.env['omniauth.auth'].except('extra')
+      session["devise.twitch_data"] = request.env["omniauth.auth"].except("extra")
       redirect_to new_user_registration_url
     end
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,21 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # CSRFトークンの検証をスキップ（必要に応じて）
+  skip_before_action :verify_authenticity_token, only: [:twitch]
+
+  def twitch
+    # OmniAuthから認証情報を取得
+    @user = User.from_omniauth(request.env['omniauth.auth'])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: 'Twitch') if is_navigational_format?
+    else
+      session['devise.twitch_data'] = request.env['omniauth.auth'].except('extra')
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,10 @@
 class UsersController < ApplicationController
   # TOPページに遷移
   def index
-
   end
 
   # 認証失敗のアクション
   def failure
     redirect_to root_path
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,12 @@
 class UsersController < ApplicationController
   # TOPページに遷移
   def index
+
   end
+
+  # 認証失敗のアクション
+  def failure
+    redirect_to root_path
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: [:twitch]
 
   # Deviseがemailやpasswordのバリデーションを矯正しないようにする
   def email_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [:twitch]
+         :omniauthable, omniauth_providers: [ :twitch ]
 
   # Deviseがemailやpasswordのバリデーションを矯正しないようにする
   def email_required?

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module TwichClipFinder
     config.load_defaults 7.2
 
     config.session_store :cookie_store, key: "_twitch_clip_finder_session"
-    
+
     config.autoload_lib(ignore: %w[assets tasks])
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,14 +2,15 @@ require_relative "boot"
 
 require "rails/all"
 
-config.session_store :cookie_strore, key: "TwitchClipFinder"
 Bundler.require(*Rails.groups)
 
-module Myapp
+module TwichClipFinder
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    config.session_store :cookie_store, key: "_twitch_clip_finder_session"
+    
     config.autoload_lib(ignore: %w[assets tasks])
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,8 +2,7 @@ require_relative "boot"
 
 require "rails/all"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
+config.session_store :cookie_strore, key: 'TwitchClipFinder'
 Bundler.require(*Rails.groups)
 
 module Myapp
@@ -11,17 +10,6 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
-
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,7 @@ require_relative "boot"
 
 require "rails/all"
 
-config.session_store :cookie_strore, key: 'TwitchClipFinder'
+config.session_store :cookie_strore, key: "TwitchClipFinder"
 Bundler.require(*Rails.groups)
 
 module Myapp

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -29,5 +29,5 @@ Devise.setup do |config|
   config.omniauth :twitch, ENV["TWITCH_CLIENT_ID"], ENV["TWITCH_CLIENT_SECRET"], scope: "user:read:email user:read:follows"
 
   # OmniAuthでGETとPOSTリクエストを許可
-  OmniAuth.config.allowed_request_methods = [:get, :post]
+  OmniAuth.config.allowed_request_methods = [ :get, :post ]
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -27,4 +27,7 @@ Devise.setup do |config|
 
   # Twitch認証
   config.omniauth :twitch, ENV["TWITCH_CLIENT_ID"], ENV["TWITCH_CLIENT_SECRET"], scope: "user:read:email user:read:follows"
+
+  # OmniAuthでGETとPOSTリクエストを許可
+  OmniAuth.config.allowed_request_methods = [:get, :post]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # ログイン・ログアウト用route
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 
   # root_path
   root "users#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # ログイン・ログアウト用route
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   # root_path
   root "users#index"

--- a/db/migrate/20241002125021_add_omniauth_to_users.rb
+++ b/db/migrate/20241002125021_add_omniauth_to_users.rb
@@ -1,0 +1,5 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :provider, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_29_103316) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_02_125021) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_29_103316) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider"
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 end


### PR DESCRIPTION
## 概要
ユーザー登録機能（認証機能）を実装するため、TwitchAPIに認証リクエストを送るControllerを作成する

## 実装
- [X] `index`アクションに以下のメソッドを追加する
  - [X] `twitch` メソッド：TwitchのOAuth認証ページにリダイレクトする
    - OAuth用のURLを生成し、リダイレクト
    - `state` パラメータを使用してCSRFを防止
  - [X] `callback` メソッド：Twitchからのコールバックを受け取り、アクセストークンとユーザー情報を取得
    - `code` を受け取り、Twitch APIにアクセストークンリクエストを送信
    - アクセストークンを使用して、Twitchユーザー情報を取得
    - 取得した情報でユーザーを作成または更新
 - [X] `destroy` アクション：ユーザーのサインアウト処理を行う
    - ユーザーのセッションをリセットし、ログアウト処理を行う
## テスト
> - PostmanにPOSTリクエストを送信し、以下を確認
  >  - `/auth/twitch` にアクセスした際に、TwitchのOAuth認証ページにリダイレクトされること
  >  - `/auth/twitch/callback` に正しいパラメータ（`code`と`state`）を渡した際に、ステータス> 200が返り、ユーザーが正しく作成・ログインされること

上記はpostmanではCSRF制約があり、postmanでの検証はできなかった。
その代わり、以下のURLで認証画面に行くことを確認
https://id.twitch.tv/oauth2/authorize?client_id=ekrwi23agdtbnbi89k7034momvlit7&redirect_uri=http://localhost:3000/users/auth/twitch/callback&response_type=code&scope=user:read:email
  

## 関連Issue
#11  #13 
