### PR TITLE
クリップ表示機能の実装

### DIFF
--- a/app/controllers/streamers_controller.rb
+++ b/app/controllers/streamers_controller.rb
@@ -1,0 +1,70 @@
+class StreamersController < ApplicationController
+  def show
+    streamer_name = params[:name]
+    streamer_id = get_streamer_id(streamer_name)
+
+    if streamer_id
+      clips = fetch_clips(streamer_id)
+
+      if clips.any?
+        @clips = clips
+        respond_to do |format|
+          format.html # show.html.erbを通常通りレンダリング
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.replace("main-content", partial: "streamers/clips", locals: { clips: @clips })
+          end
+        end
+      else
+        render turbo_stream: turbo_stream.replace("main-content", partial: "streamers/clips", locals: { clips: [] })
+      end
+    else
+      render turbo_stream: turbo_stream.replace("main-content", partial: "streamers/clips", locals: { clips: [] })
+    end
+  end
+
+  private
+
+  # 配信者IDを取得するメソッド
+  def get_streamer_id(streamer_name)
+    # Twitch APIから配信者IDを取得するロジック
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    response = send_twitch_request("users", { login: streamer_name }, access_token)
+    return unless response.success?
+
+    user_data = JSON.parse(response.body)
+    user_data["data"].first["id"] if user_data["data"].any?
+  end
+
+  private
+
+  # 配信者のユーザーIDを取得する
+  def get_streamer_id(streamer_name)
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    response = send_twitch_request("users", { login: streamer_name }, access_token)
+    return unless response.success?
+
+    user_data = JSON.parse(response.body)
+    user_data["data"].first["id"] if user_data["data"].any?
+  end
+
+  # クリップを取得する
+  def fetch_clips(streamer_id)
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    response = send_twitch_request("clips", { broadcaster_id: streamer_id }, access_token)
+    return [] unless response.success?
+
+    clips = JSON.parse(response.body)["data"]
+    clips.select { |clip| clip["language"] == "ja" }
+  end
+
+  # Twitch APIへのリクエスト送信
+  def send_twitch_request(endpoint, params, access_token)
+    Faraday.get("https://api.twitch.tv/helix/#{endpoint}") do |req|
+      req.params = params
+      req.headers["Authorization"] = "Bearer #{access_token}"
+      req.headers["Client-ID"] = ENV["TWITCH_CLIENT_ID"]
+      req.options.timeout = 10  # タイムアウト設定 (秒)
+      req.options.open_timeout = 10  # 接続時のタイムアウト (秒)
+    end
+  end
+end

--- a/app/helpers/streamers_helper.rb
+++ b/app/helpers/streamers_helper.rb
@@ -1,0 +1,2 @@
+module StreamersHelper
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -3,7 +3,7 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true
 window.Stimulus   = application
 
 export { application }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import TwitchClipsLoaderController from "./twitch_clips_loader_controller"
+application.register("twitch-clips-loader", TwitchClipsLoaderController)

--- a/app/javascript/controllers/twitch_clips_loader_controller.js
+++ b/app/javascript/controllers/twitch_clips_loader_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["iframe", "container", "loading"]
+
+  connect() {
+    console.log("Stimulus controller connected");
+    this.loadedCount = 0;
+    this.totalIframes = this.iframeTargets.length;
+
+    console.log("Total iframes: ", this.totalIframes);
+
+    // iframeがロードされたときのイベントリスナーを追加
+    this.iframeTargets.forEach(iframe => {
+      iframe.addEventListener('load', () => {
+        this.handleIframeLoad();
+      });
+    });
+  }
+
+  handleIframeLoad() {
+    this.loadedCount += 1;
+    console.log("Loaded iframe count: ", this.loadedCount);
+
+    // すべてのiframeがロードされた場合に実行
+    if (this.loadedCount === this.totalIframes) {
+      this.showClips();
+    }
+  }
+
+  showClips() {
+    // ローディングマークを消して、コンテナを表示
+    this.loadingTarget.style.display = "none";
+    this.containerTarget.style.opacity = "1";
+    console.log("All iframes loaded, showing container");
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,104 +15,108 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+
   </head>
 
   <body class="bg-gray-100 flex flex-col min-h-screen">
-  <!-- ナビゲーションヘッダー -->
-  <header class="navbar bg-gray-800 text-white px-4 py-2 flex justify-between items-center">
-    <!-- ロゴとリンク -->
-    <div class="flex items-center space-x-4">
-      <!-- ロゴ -->
-      <div class="text-purple-500">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l5-5m0 0l-5-5m5 5H6" />
-        </svg>
-      </div>
-      <a href="#" class="text-white hover:text-purple-500">利用規約</a>
-      <a href="#" class="text-white hover:text-purple-500">使い方</a>
-    </div>
-
-    <!-- 検索バーとログイン -->
-    <div class="flex items-center space-x-12">
-      <!-- ゲーム名検索 -->
-      <div class="flex items-center gap-2">
-        <input type="text" placeholder="ゲーム検索" class="input input-bordered w-[300px] text-white bg-gray-700 border-gray-600">
-        <button class="btn btn-square btn-ghost text-white">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
-            <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
+    <!-- ナビゲーションヘッダー -->
+    <header class="navbar bg-gray-800 text-white px-4 py-2 flex justify-between items-center fixed top-0 left-0 right-0 z-50">
+      <!-- ロゴとリンク -->
+      <div class="flex items-center space-x-4">
+        <!-- ロゴ -->
+        <div class="text-purple-500">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l5-5m0 0l-5-5m5 5H6" />
           </svg>
-        </button>
+        </div>
+        <a href="#" class="text-white hover:text-purple-500">利用規約</a>
+        <a href="#" class="text-white hover:text-purple-500">使い方</a>
       </div>
 
-      <!-- 配信者ID検索 -->
-      <div class="flex items-center gap-2">
-        <input type="text" placeholder="配信者ID検索" class="input input-bordered w-[300px] text-gray-400 bg-gray-700 border-gray-600">
-        <button class="btn btn-square btn-ghost text-white">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
-            <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
-          </svg>
-        </button>
-      </div>
+      <!-- 検索バーとログイン -->
+      <div class="flex items-center space-x-12">
+        <!-- ゲーム名検索 -->
+        <div class="flex items-center gap-2">
+          <input type="text" placeholder="ゲーム検索" class="input input-bordered w-[300px] text-white bg-gray-700 border-gray-600">
+          <button class="btn btn-square btn-ghost text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
+              <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
+            </svg>
+          </button>
+        </div>
 
-      <% if user_signed_in? %>
-        <div class="dropdown dropdown-end">
-          <div tabindex="0" role="button" class="avatar m-1">
-            <div class="w-12 rounded-full">
-              <%= image_tag(current_user.profile_image_url, alt: "プロフィール画像", class: "profile-image", width: "50", height: "50") if current_user.profile_image_url.present? %>
-            </div>
+        <form action="/streamers/show" method="get" data-turbo-frame="clips">
+          <div class="flex items-center gap-2">
+            <input type="text" name="name" placeholder="配信者ID検索" class="input input-bordered w-[300px] text-gray-400 bg-gray-700 border-gray-600">
+            <button type="submit" class="btn btn-square btn-ghost text-white" data: { turbo_stream: true }>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
+                <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
+              </svg>
+            </button>
           </div>
-          <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-            <li><a href="#">プロフィール</a></li>
-            <li><a href="#">設定</a></li>
-            <li>
-              <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-white-500 no-button-style" %>
-            </li>
-          </ul>
-        </div>
-      <% else %>
-        <%= button_to "ログイン", user_twitch_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-secondary" %>
-      <% end %>
-    </div>
-  </header>
+        </form>
 
-  <div class="flex flex-1 min-h-screen">
-    <!-- サイドバー -->
-    <aside class="w-64 bg-gray-900 p-4">
-      <h2 class="text-xl font-bold text-white mb-6">フォローしているチャンネル</h2>
-
-      <% if current_user.present? %>
-        <% if @followed_channels.present? %>
-          <ul class="space-y-4">
-            <% @followed_channels.each do |follow| %>
-              <li class="flex items-center space-x-4 p-2 hover:bg-gray-800 rounded">
-                <img src="<%= follow['profile_image_url'] %>" alt="<%= follow['broadcaster_name'] %>" class="w-10 h-10 rounded-full object-cover">
-                <div>
-                  <p class="text-white font-semibold"><%= follow['broadcaster_name'] %></p>
-                </div>
+        <% if user_signed_in? %>
+          <div class="dropdown dropdown-end">
+            <div tabindex="0" role="button" class="avatar m-1">
+              <div class="w-12 rounded-full">
+                <%= image_tag(current_user.profile_image_url, alt: "プロフィール画像", class: "profile-image", width: "50", height: "50") if current_user.profile_image_url.present? %>
+              </div>
+            </div>
+            <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
+              <li><a href="#">プロフィール</a></li>
+              <li><a href="#">設定</a></li>
+              <li>
+                <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-white-500 no-button-style" %>
               </li>
-            <% end %>
-          </ul>
+            </ul>
+          </div>
         <% else %>
-          <p class="text-white">フォローリストがありません。</p>
-        <% end %>
-      <% else %>
-        <!-- ログインしていない場合のログインボタン -->
-        <div class="flex justify-center">
           <%= button_to "ログイン", user_twitch_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-secondary" %>
-        </div>
-      <% end %>
-    </aside>
+        <% end %>
+      </div>
+    </header>
 
-    <!-- メインコンテンツ -->
-    <main class="flex-1 p-6 bg-gray-100">
-      <!-- メインコンテンツをここに表示 -->
-      <%= yield %>
-    </main>
-  </div>
+    <div class="flex flex-1 min-h-screen pt-16">
+      <!-- サイドバー -->
+        <aside class="w-64 bg-gray-900 p-4 fixed top-16 bottom-0 left-0 overflow-y-auto z-40">
+          <h2 class="text-xl font-bold text-white mb-6">フォローしているチャンネル</h2>
+          <% if current_user.present? %>
+            <% if @followed_channels.present? %>
+              <ul class="space-y-4">
+                <% @followed_channels.each do |follow| %>
+                  <li class="flex items-center space-x-4 p-2 hover:bg-gray-800 rounded">
+                    <img src="<%= follow['profile_image_url'] %>" alt="<%= follow['broadcaster_name'] %>" class="w-10 h-10 rounded-full object-cover">
+                    <div>
+                      <p class="text-white font-semibold"><%= follow['broadcaster_name'] %></p>
+                    </div>
+                  </li>
+                <% end %>
+              </ul>
+            <% else %>
+              <p class="text-white">フォローリストがありません。</p>
+            <% end %>
+          <% else %>
+            <div class="flex justify-center">
+              <%= button_to "ログイン", user_twitch_omniauth_authorize_path, data: { turbo: false }, class: "btn btn-secondary" %>
+            </div>
+          <% end %>
+        </aside>
 
-  <!-- フッター -->
-  <footer class="bg-gray-800 text-white text-center p-4">
-    <p>&copy; 2024 TODOアプリ. All Rights Reserved.</p>
-  </footer>
-</body>
+
+  
+      <!-- メインコンテンツ -->
+      <main class="flex-1 p-6 bg-gray-100 ml-64">
+      <%= turbo_frame_tag "clips" do %>
+        <%= yield %>
+        <% end %>
+      </main>
+    
+    </div>
+
+    <!-- フッター -->
+    <footer class="bg-gray-800 text-white text-center p-4">
+      <p>&copy; 2024 TODOアプリ. All Rights Reserved.</p>
+    </footer>
+  </body>
 </html>

--- a/app/views/streamers/_clips.html.erb
+++ b/app/views/streamers/_clips.html.erb
@@ -1,0 +1,32 @@
+<%= turbo_frame_tag "clips" do %>
+  <% if clips.any? %>
+    <div data-controller="twitch-clips-loader">
+      <!-- ローディング中の表示 -->
+      <div data-twitch-clips-loader-target="loading">
+        <span class="loading loading-ring loading-lg"></span>
+        <p>ローディング中,,,,</p>
+      </div>
+
+      <!-- クリップコンテナ（最初は非表示） -->
+      <div data-twitch-clips-loader-target="container" id="clips-container" style="opacity: 0; transition: opacity 2s ease-in-out;">
+        <% clips.each do |clip| %>
+          <div class="clip-container">
+            <p>クリップタイトル: <%= clip['title'] %> - 配信者: <%= clip['broadcaster_name'] %></p>
+            <iframe
+              data-twitch-clips-loader-target="iframe"
+              class="twitch-clip"
+              src="https://clips.twitch.tv/embed?clip=<%= clip['id'] %>&parent=<%= ENV['TWITCH_PARENT_URL'] %>"  
+              height="300"
+              width="400"
+              frameborder="0"
+              scrolling="no"
+              allowfullscreen="true">
+            </iframe>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <p>クリップが見つかりませんでした。</p>
+  <% end %>
+<% end %>

--- a/app/views/streamers/show.html.erb
+++ b/app/views/streamers/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "clips", locals: { clips: @clips } %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
   # root_path
   root "users#index"
 
-
+   # 'name' をクエリパラメータとして受け取るルートを追加
+   get "streamers/show", to: "streamers#show"
+   # APIでストリーマーのデータを取得するためのルート
+   get "streamers/:name", to: "streamers#show"
 
   # CI/CD用route
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/stremers_controller_test.rb
+++ b/test/controllers/stremers_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class StreamersControllerTest < ActionDispatch::IntegrationTest
-  test "should get show" do
-    get streamers_show_url
-    assert_response :success
-  end
-end

--- a/test/controllers/stremers_controller_test.rb
+++ b/test/controllers/stremers_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class StreamersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get streamers_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
配信者名を検索した際に、検索した配信者のクリップが表示されるように実装する
## 変更点

- `app/controller/seach/streamers_controller.rb`の追加
  - viewから配信者名を受け取り、それを元にAPIリクエストを送り、配信者のクリップを取得する 
- `app/views/streamers/show.html.erb`の追加
  - バックから送られてきたクリップを表示させる。また、検索している間はローディングアイコンを出し、全てが閲覧可能状態になった場合に、動画を表示する 

## 影響範囲
- turbo_streamをする際に、フォローリストも更新してしまいフォローリストが空になってしまった。
  - turbo_streamの変更箇所を明確にし対処  

## テスト

- nacho_dayoで検索をし、クリップが表示されるか
- 検索している間、ローディングアイコンが表示されるか
- 全ての動画が閲覧可能状態になるまで、動画が表示されないか

## 関連Issue
#7 
