### PR TITLE
ゲーム名検索　実装

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,182 @@
+class GamesController < ApplicationController
+  # ゲームIDを使ってクリップを表示するアクション
+  def show
+    game_name = params[:name]
+    Rails.logger.info "Game Name received: #{game_name}"
+
+    # params[:name]が数値かどうかを判定し、数値ならそのままIDとして使用
+    game_id = if numeric?(game_name)
+                Rails.logger.info "Game Name is numeric, using it as ID directly"
+                game_name
+    else
+                Rails.logger.info "Game Name is not numeric, calling get_game_info"
+                game_info = get_game_info(game_name)
+                game_info ? game_info[:id] : nil
+    end
+
+    if game_id
+      # ゲームIDからボックスアートURLを取得
+      box_art_url = fetch_game_box_art(game_id)
+      @game_info = { id: game_id, box_art_url: box_art_url }
+
+      Rails.logger.info "Game Info: #{@game_info.inspect}"
+
+      cursor = params[:cursor] # ページネーション用のカーソル
+      clips, pagination = fetch_clips(@game_info[:id], cursor)
+
+      if clips.any?
+        @next_cursor = pagination["cursor"]
+
+        @clips = Kaminari.paginate_array(clips).page(params[:page]).per(12)
+        @total_pages = @clips.total_pages
+
+        respond_to do |format|
+          format.html
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.append("clips", partial: "games/clips", locals: { clips: @clips, next_cursor: @next_cursor })
+          end
+        end
+      else
+        render_no_clips(game_name)
+      end
+    else
+      Rails.logger.info "No game info found for #{game_name}"
+      render_no_clips(game_name)
+    end
+  end
+
+  private
+
+  # ゲームのボックスアート（アイコン）を取得するメソッド
+  def fetch_game_box_art(game_id)
+    Rails.logger.info "fetch_game_box_art called with Game ID: #{game_id}"
+
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    response = send_twitch_request("games", { id: game_id }, access_token)
+
+    return unless response.success?
+
+    game_data = JSON.parse(response.body)
+
+    if game_data["data"].any?
+      box_art_url = game_data["data"].first["box_art_url"]
+      Rails.logger.info "Box Art URL before replace: #{box_art_url}"
+
+      # プレースホルダーを置き換え
+      box_art_url = box_art_url.gsub("{width}", "150").gsub("{height}", "200")
+
+      Rails.logger.info "Box Art URL after replace: #{box_art_url}"
+      box_art_url
+    else
+      Rails.logger.info "No game data found for Game ID: #{game_id}"
+      nil
+    end
+  end
+
+  # ゲーム情報を取得するメソッド（名前からIDに変換）
+  def get_game_info(game_name)
+    Rails.logger.info "get_game_info called with Game Name: #{game_name}"
+
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    response = send_twitch_request("games", { name: game_name }, access_token)
+
+    return unless response.success?
+
+    game_data = JSON.parse(response.body)
+    if game_data["data"].any?
+      {
+        id: game_data["data"].first["id"],
+        box_art_url: game_data["data"].first["box_art_url"]
+      }
+    else
+      Rails.logger.info "No game data found for Game Name: #{game_name}"
+      nil
+    end
+  end
+
+  # ゲームIDでクリップを取得するメソッド（ページネーション対応）
+  def fetch_clips(game_id, cursor = nil)
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    params = {
+      game_id: game_id,
+      first: 80, # 一度に取得するクリップ数
+      after: cursor # 次のページのカーソル
+    }.compact
+
+    response = send_twitch_request("clips", params, access_token)
+    return [ [], {} ] unless response.success?
+
+    data = JSON.parse(response.body)
+    clips = data["data"]
+    pagination = data["pagination"]
+
+    # 日本語のクリップのみをフィルタリング
+    clips.select! { |clip| clip["language"] == "ja" }
+
+    # 配信者IDの一覧を取得
+    broadcaster_ids = clips.map { |clip| clip["broadcaster_id"] }.uniq
+
+    # 配信者情報（アイコン、名前）を一括で取得
+    broadcaster_info = fetch_broadcaster_info(broadcaster_ids)
+
+    # 各クリップに配信者の名前とプロフィール画像を追加
+    clips.each do |clip|
+      clip["broadcaster_name"] = broadcaster_info[clip["broadcaster_id"]][:name]
+      clip["broadcaster_profile_image"] = broadcaster_info[clip["broadcaster_id"]][:profile_image_url]
+    end
+
+    [ clips, pagination ]
+  end
+
+  # 複数の配信者IDから名前とアイコンを取得するメソッド
+  def fetch_broadcaster_info(broadcaster_ids)
+    return {} if broadcaster_ids.empty?
+
+    access_token = ENV["TWITCH_ACCESS_TOKEN"]
+    broadcaster_info = {}
+
+    # Twitch APIは一度に最大100件のIDを受け取れる
+    broadcaster_ids.each_slice(100) do |ids|
+      response = send_twitch_request("users", { id: ids }, access_token)
+      next unless response.success?
+
+      data = JSON.parse(response.body)
+      data["data"].each do |broadcaster|
+        broadcaster_info[broadcaster["id"]] = {
+          name: broadcaster["display_name"],
+          profile_image_url: broadcaster["profile_image_url"]
+        }
+      end
+    end
+
+    broadcaster_info
+  end
+
+  # APIリクエストを送信する汎用メソッド
+  def send_twitch_request(endpoint, params, access_token)
+    Faraday.get("https://api.twitch.tv/helix/#{endpoint}") do |req|
+      req.params = params
+      req.headers["Authorization"] = "Bearer #{access_token}"
+      req.headers["Client-ID"] = ENV["TWITCH_CLIENT_ID"]
+      req.options.timeout = 10
+      req.options.open_timeout = 10
+    end
+  end
+
+  # 数値かどうかを判定するヘルパーメソッド
+  def numeric?(string)
+    string.match?(/\A\d+\z/)
+  end
+
+  # クリップが見つからない場合のレスポンスを統一
+  def render_no_clips(game_name)
+    respond_to do |format|
+      format.html do
+        render partial: "games/clips", locals: { clips: [], game_name: game_name, next_cursor: nil }
+      end
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace("clips", partial: "games/clips", locals: { clips: [], game_name: game_name, next_cursor: nil })
+      end
+    end
+  end
+end

--- a/app/controllers/streamers_controller.rb
+++ b/app/controllers/streamers_controller.rb
@@ -1,7 +1,7 @@
 class StreamersController < ApplicationController
   # 配信者のクリップを表示するアクション
   def show
-    streamer_name = params[:name] # params[:name]を使用
+    streamer_name = params[:name]
 
     # params[:name]が数値かどうかを判定し、数値ならそのままIDとして使用
     if numeric?(streamer_name)
@@ -15,18 +15,15 @@ class StreamersController < ApplicationController
       clips, pagination = fetch_clips(@streamer_info[:id], cursor)
 
       if clips.any?
-        @next_cursor = pagination["cursor"] # 次のページのカーソル
+        @next_cursor = pagination["cursor"]
 
         # @clips に対して配列ベースのページネーションを設定
-        @clips = Kaminari.paginate_array(clips).page(params[:page]).per(12) # 1ページに12個のクリップを表示
+        @clips = Kaminari.paginate_array(clips).page(params[:page]).per(12)
         @total_pages = @clips.total_pages
 
-        # @next_cursor の内容をログに出力して確認
-        Rails.logger.debug "Next Cursor: #{@next_cursor.inspect}"
-
         respond_to do |format|
-          format.html # HTMLリクエストの場合、ビューを通常通りレンダリング
-          format.turbo_stream do # Turbo Streamリクエストの場合、部分的に更新
+          format.html
+          format.turbo_stream do
             render turbo_stream: turbo_stream.append("clips", partial: "streamers/clips", locals: { clips: @clips, next_cursor: @next_cursor })
           end
         end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,0 +1,2 @@
+module GamesHelper
+end

--- a/app/javascript/controllers/game_search_controller.js
+++ b/app/javascript/controllers/game_search_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input"]
+
+  connect() {
+    this.modal = document.getElementById("alert-modal"); // モーダルを取得
+    this.closeButton = document.getElementById("close-modal"); // モーダルの閉じるボタンを取得
+
+    // モーダルの閉じるボタンにクリックイベントを追加
+    this.closeButton.addEventListener("click", () => {
+      this.closeModal();
+    });
+  }
+
+  submit(event) {
+    // 入力が空かどうかをチェック
+    if (this.inputTarget.value.trim() === "") {
+      event.preventDefault(); // フォーム送信を防止
+      this.showModal(); // モーダルを表示
+    }
+  }
+
+  showModal() {
+    // モーダルを表示するためのクラスを追加
+    this.modal.classList.add("modal-open");
+  }
+
+  closeModal() {
+    // モーダルを閉じるためのクラスを削除
+    this.modal.classList.remove("modal-open");
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import ClipLoaderController from "./clip_loader_controller"
 application.register("clip-loader", ClipLoaderController)
 
+import GameSearchController from "./game_search_controller"
+application.register("game-search", GameSearchController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/games/_clip.html.erb
+++ b/app/views/games/_clip.html.erb
@@ -1,0 +1,54 @@
+<!-- 単一のクリップカード -->
+<div class="clip-container p-4 relative rounded-lg border-b-4 border-gray-200 flex flex-col justify-between">
+  <!-- 動画部分 -->
+  <figure class="relative">
+    <iframe
+      src="https://clips.twitch.tv/embed?clip=<%= clip['id'] %>&parent=<%= ENV['TWITCH_PARENT_URL'] %>"
+      scrolling="no"
+      allowfullscreen="true"
+      class="w-full h-auto"
+      style="max-width: 100%; height: 300px;"
+    ></iframe>
+  </figure>
+
+  <!-- クリップ情報 -->
+  <div class="pl-4 w-full max-w-full">
+    <div class="flex items-start">
+      <!-- 配信者アイコン -->
+      <img
+        src="<%= clip['broadcaster_profile_image'] %>"
+        alt="<%= clip['broadcaster_name'] %>"
+        class="w-10 h-10 rounded-full object-cover mr-4"
+        loading="lazy"
+      />
+      <div>
+        <!-- クリップタイトル -->
+        <h2 class="text-lg font-bold mb-1 truncate">
+          <%= clip['title'] %>
+        </h2>
+        <!-- 配信者名 -->
+        <p class="text-sm text-gray-600 mb-1">
+          <%= clip['broadcaster_name'] %>
+        </p>
+        <!-- ゲーム名 -->
+        <p class="text-sm text-gray-500">
+          <%= clip['game_name'] %>
+        </p>
+        <!-- クリップ作成者名 -->
+        <p class="text-sm text-gray-600">
+          作成者: <%= clip['creator_name'] %>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <!-- 保存ボタン -->
+  <div class="flex justify-end mt-2">
+    <button class="btn btn-primary bg-purple-600 hover:bg-purple-700 text-white border-none flex items-center px-3 py-1 rounded transition-colors duration-200">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
+      </svg>
+      <span>保存</span>
+    </button>
+  </div>
+</div>

--- a/app/views/games/_clips.html.erb
+++ b/app/views/games/_clips.html.erb
@@ -1,0 +1,52 @@
+<%= turbo_frame_tag "clips" do %>
+  <% if clips.any? %>
+    <!-- ゲームアイコンと名前の表示 -->
+    <% if @game_info.present? %>
+      <div class="flex items-center mb-4">
+        <img
+          src="<%= @game_info[:box_art_url] %>"
+          alt="<%= @game_info[:name] %>"
+          class="w-16 h-16 object-cover rounded mr-4"
+        />
+        <h1 class="text-2xl font-bold text-gray-800">
+          <%= @game_info[:name] %>
+        </h1>
+      </div>
+    <% end %>
+
+    <!-- クリップ一覧 -->
+    <div id="clips-container" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% clips.each do |clip| %>
+        <div class="relative">
+          <!-- 各クリップをレンダリング -->
+          <%= render partial: "games/clip", locals: { clip: clip } %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- ページネーションリンク -->
+    <div class="pagination-links mt-6 flex justify-center" data-controller="pagination-scroll" data-pagination-scroll-target="pagination">
+      <%= paginate @clips %>
+    </div>
+  <% else %>
+    <!-- エラーメッセージ表示 -->
+    <div class="bg-gray-800 border-l-4 border-red-500 p-4 my-4 rounded-r-md shadow-md">
+      <div class="flex items-start">
+        <!-- アイコン -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-red-500 mr-3 flex-shrink-0 mt-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01m-6.938-4a9.003 9.003 0 1113.856 0A9.003 9.003 0 015.062 12z" />
+        </svg>
+        <div class="flex-grow">
+          <p class="font-semibold text-red-400">エラーが発生しました</p>
+          <div class="mt-3">
+            <p class="text-sm text-gray-400">以下をお試しください：</p>
+            <ul class="list-disc list-inside text-sm text-gray-400 mt-1 space-y-1">
+              <li>ゲームIDを確認する</li>
+              <li>別のゲームIDを試す</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,4 @@
+<!-- app/views/games/show.html.erb -->
+<div id="main-content">   
+<%= render partial: "games/clips", locals: { clips: @clips, game_name: @game_info[:name], next_cursor: @next_cursor } %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,18 +36,21 @@
       <!-- 検索バーとログイン -->
       <div class="flex items-center space-x-12">
         <!-- ゲーム名検索 -->
-        <div class="flex items-center gap-2">
-          <input type="text" placeholder="ゲーム検索" class="input input-bordered w-[300px] text-white bg-gray-700 border-gray-600">
-          <button class="btn btn-square btn-ghost text-white">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
-              <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
-            </svg>
-          </button>
-        </div>
+        <form action="/games/show" method="get" data-turbo-frame="clips">
+          <div class="flex items-center gap-2">
+            <input type="text" name="name" placeholder="ゲーム検索" class="input input-bordered w-[300px] text-gray-400 bg-gray-700 border-gray-600">
+            <button type="submit" class="btn btn-square btn-ghost text-white">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
+                <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />
+              </svg>
+            </button>
+          </div>
+        </form>
 
+        <!-- 配信者ID検索 -->
         <form action="/streamers/show" method="get" data-turbo-frame="clips">
           <div class="flex items-center gap-2">
-            <input type="text" data-streamer-search-target="input" name="name" placeholder="配信者ID検索" class="input input-bordered w-[300px] text-gray-400 bg-gray-700 border-gray-600">
+            <input type="text" name="name" placeholder="配信者ID検索" class="input input-bordered w-[300px] text-gray-400 bg-gray-700 border-gray-600">
             <button type="submit" class="btn btn-square btn-ghost text-white">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
                 <path fill-rule="evenodd" d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06l-2.755-2.754ZM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0Z" clip-rule="evenodd" />

--- a/app/views/streamers/show.html.erb
+++ b/app/views/streamers/show.html.erb
@@ -1,5 +1,3 @@
-<!-- app/views/streamers/show.html.erb -->
-<div id="main-content">
-<%= render partial: "streamers/clips", locals: { clips: @clips, streamer_name: @streamer_info[:name], next_cursor: @next_cursor } %>
+  <!-- クリップのレンダリング -->
+  <%= render partial: "streamers/clips", locals: { clips: @clips, streamer_name: @streamer_info[:name], next_cursor: @next_cursor } %>
 </div>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,11 @@ Rails.application.routes.draw do
   # root_path
   root "users#index"
 
-  # 静的なルートを優先
-  get "streamers/show", to: "streamers#show", as: "streamer_show"
+  # 配信者ID検索用ルート
+  get "streamers/show", to: "streamers#show"
 
-  # 動的なルートは下に定義
-  get "streamers/:name", to: "streamers#show", as: "streamer"
+  # ゲームID検索用ルート
+  get "games/show", to: "games#show"
 
 
   # CI/CD用route

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GamesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
ゲーム名検索を実装するために、TwitchAPIにGETリクエストを送る`games_controller.rb`を作成してクリップを表示させる

* 関連するIssueやプルリクエスト
#9 

## なぜこの変更をするのか
ゲーム名で検索した際にクリップを表示させ、ユーザーが見たいゲームのクリップを取得するため

* 変更をする理由
今の状態だと、検索ボックスのままで検索することができないため

## やったこと

* [x] `games_controller.rb`の作成
* [x] `show`アクションの作成
* [x] `html.erb`ファイルの作成    
* [x] クリップの表示 

## 変更内容

* UIの変更ならスクリーンショット
 * クリップの表示
 * 
<img width="1693" alt="image" src="https://github.com/user-attachments/assets/c98f932f-34af-4848-b84d-46ce99a1af9a">

## 影響範囲

* ユーザーに影響すること
 * クリップが表示される　 
* システムに影響すること
 * クリップが表示される  

## どうやるのか
 * ゲーム名検索テキストボックスで「VALORANT」と入力する
