### PR TITLE
clipsテーブル、stremerテーブル、gameテーブルの実装

### DIFF
--- a/app/models/clip.rb
+++ b/app/models/clip.rb
@@ -1,0 +1,19 @@
+class Clip < ApplicationRecord
+  # アソシエーション
+  belongs_to :streamer, class_name: "Streamer", foreign_key: "streamer_id"
+  belongs_to :game, class_name: "Game", foreign_key: "game_id"
+
+  has_many :playlist_clips, dependent: :destroy
+  has_many :playlists, through: :playlist_clips
+
+  has_many :fovorite_clips, dependent: :destroy
+  has_many :favorited_by, through: :favorite_clips, source: :user
+
+  # バリデーション
+  validates :clip_id, presence: true, uniqueness: true
+  validates :streamer_id, presence: true
+  validates :game_id, presence: true
+  validates :title, presence: true
+  validates :duration, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :view_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,7 @@
+class Game < ApplicationRecord
+  # アソシエーション
+  has_many :clips, foreign_key: "game_id", dependent: :destroy
+
+  # バリデーション
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/streamer.rb
+++ b/app/models/streamer.rb
@@ -1,0 +1,8 @@
+class Streamer < ApplicationRecord
+  # アソシエーション
+  has_many :clips, foreign_key: "streamer_id", dependent: :destroy
+
+  # バリデーション
+  validates :login, presence: true, uniqueness: true
+  validates :display_name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,14 @@
 class User < ApplicationRecord
+  # アソシエーション
+  has_many :playlists, foreign_key: "user_uid", primary_key: "uid", dependent: :destroy
+  has_many :favorite_clips, foreign_key: "user_uid", primary_key: "uid", dependent: :destroy
+  has_many :favorited_clips, through: :favorite_clips, source: :clip
+
+  # バリデーション
+  validates :email, presence: true, uniqueness: true
+  validates :encrypted_password, presence: true
+
+
   devise :database_authenticatable, :registerable, :recoverable, :rememberable,
          :omniauthable, omniauth_providers: [ :twitch ]
 

--- a/db/migrate/20241027072926_create_streamers.rb
+++ b/db/migrate/20241027072926_create_streamers.rb
@@ -1,0 +1,13 @@
+class CreateStreamers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :streamers do |t|
+      t.string :login, null: false
+      t.string :display_name, null: false
+      t.string :profile_image_url
+      t.string :language
+      t.timestamps
+    end
+    add_index :streamers, :login, unique: true
+    add_index :streamers, :display_name
+  end
+end

--- a/db/migrate/20241027073040_create_games.rb
+++ b/db/migrate/20241027073040_create_games.rb
@@ -1,0 +1,10 @@
+class CreateGames < ActiveRecord::Migration[7.2]
+  def change
+    create_table :games do |t|
+      t.string :name, null: false
+      t.string :box_art_url
+      t.timestamps
+    end
+    add_index :games, :name, unique: true
+  end
+end

--- a/db/migrate/20241027073125_create_clips.rb
+++ b/db/migrate/20241027073125_create_clips.rb
@@ -1,0 +1,19 @@
+class CreateClips < ActiveRecord::Migration[7.2]
+  def change
+    create_table :clips do |t|
+      t.string :clip_id, null: false
+      t.references :streamer, null: false, foreign_key: true, type: :bigint
+      t.references :game, null: false, foreign_key: true, type: :bigint
+      t.string :language
+      t.string :title
+      t.timestamp :clip_created_at
+      t.string :thumbnail_url
+      t.integer :duration
+      t.integer :view_count
+      t.timestamps
+    end
+    add_index :clips, :clip_id, unique: true
+    add_index :clips, :clip_created_at
+    add_index :clips, [ :game_id, :clip_created_at ]
+  end
+end

--- a/db/migrate/20241027081348_rename_login_to_streamer_id_in_streamers.rb
+++ b/db/migrate/20241027081348_rename_login_to_streamer_id_in_streamers.rb
@@ -1,0 +1,6 @@
+class RenameLoginToStreamerIdInStreamers < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :streamers, :login, :streamer_id
+    rename_column :streamers, :display_name, :streamer_name
+  end
+end

--- a/db/migrate/20241027082103_remove_language_from_clips.rb
+++ b/db/migrate/20241027082103_remove_language_from_clips.rb
@@ -1,0 +1,5 @@
+class RemoveLanguageFromClips < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :clips, :language, :string
+  end
+end

--- a/db/migrate/20241027082428_remove_language_from_streamers.rb
+++ b/db/migrate/20241027082428_remove_language_from_streamers.rb
@@ -1,0 +1,5 @@
+class RemoveLanguageFromStreamers < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :streamers, :language, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,45 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_06_084438) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_27_082428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "clips", force: :cascade do |t|
+    t.string "clip_id", null: false
+    t.bigint "streamer_id", null: false
+    t.bigint "game_id", null: false
+    t.string "title"
+    t.datetime "clip_created_at", precision: nil
+    t.string "thumbnail_url"
+    t.integer "duration"
+    t.integer "view_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["clip_created_at"], name: "index_clips_on_clip_created_at"
+    t.index ["clip_id"], name: "index_clips_on_clip_id", unique: true
+    t.index ["game_id", "clip_created_at"], name: "index_clips_on_game_id_and_clip_created_at"
+    t.index ["game_id"], name: "index_clips_on_game_id"
+    t.index ["streamer_id"], name: "index_clips_on_streamer_id"
+  end
+
+  create_table "games", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "box_art_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_games_on_name", unique: true
+  end
+
+  create_table "streamers", force: :cascade do |t|
+    t.string "streamer_id", null: false
+    t.string "streamer_name", null: false
+    t.string "profile_image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["streamer_id"], name: "index_streamers_on_streamer_id", unique: true
+    t.index ["streamer_name"], name: "index_streamers_on_streamer_name"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "uid", default: "", null: false
@@ -30,4 +66,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_06_084438) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
+
+  add_foreign_key "clips", "games"
+  add_foreign_key "clips", "streamers"
 end

--- a/test/fixtures/clips.yml
+++ b/test/fixtures/clips.yml
@@ -1,0 +1,23 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  clip_id: MyString
+  streamer: one
+  game: one
+  language: MyString
+  title: MyString
+  clip_created_at: 2024-10-27 16:31:25
+  thumbnail_url: MyString
+  duration: 1
+  view_count: 1
+
+two:
+  clip_id: MyString
+  streamer: two
+  game: two
+  language: MyString
+  title: MyString
+  clip_created_at: 2024-10-27 16:31:25
+  thumbnail_url: MyString
+  duration: 1
+  view_count: 1

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  box_art_url: MyString
+
+two:
+  name: MyString
+  box_art_url: MyString

--- a/test/fixtures/streamers.yml
+++ b/test/fixtures/streamers.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  login: MyString
+  display_name: MyString
+  profile_image_url: MyString
+  language: MyString
+
+two:
+  login: MyString
+  display_name: MyString
+  profile_image_url: MyString
+  language: MyString

--- a/test/models/clip_test.rb
+++ b/test/models/clip_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ClipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GameTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/streamer_test.rb
+++ b/test/models/streamer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StreamerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
 - `clips`,`games`,`stremaers`の３つのテーブルの作成
- `clip`, `streamer`,`game`の３つのモデルの作成

* 変更の概要
* 関連するIssueやプルリクエスト
なし

## なぜこの変更をするのか
 - 本来はTwitchAPIで検索して表示するという形をしたかったのだが、表示される速度が遅いためAPIでリクエストしたクリップをDBに保存してそこから検索・表示という形を取るためDBを作成した

* 変更をする理由
* 前提知識がなくても分かるようにする
* 上記の理由と同じ

## やったこと

* [x] ３つのDBの作成
* [x] ３つのモデルの作成 

## 変更内容

* `schema.rb`
![image](https://github.com/user-attachments/assets/2a99100c-df69-4872-aa0f-7edb91be2f5c)


## 影響範囲

* ユーザーに影響すること
* なし
* メンバーに影響すること
* DB.モデルの追加
* システムに影響すること
* * DB.モデルの追加

## どうやるのか

* 使い方
* なし
* 再現手順
* なし
