### PR TITLE
バックグラウンドJOBの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,12 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+# Sidekiqをバックグラウンドジョブプロセッサとして使用
+gem "sidekiq"
+
+# Sidekiq Schedulerをジョブのスケジューリングに使用
+gem "sidekiq-scheduler"
+
 # Twitch関連
 gem "devise", "~> 4.9"
 gem "omniauth", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,12 +113,17 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
+    et-orbi (1.2.11)
+      tzinfo
     faraday (2.12.0)
       faraday-net_http (>= 2.0, < 3.4)
       json
       logger
     faraday-net_http (3.3.0)
       net-http
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -219,6 +224,7 @@ GEM
     public_suffix (6.0.1)
     puma (6.4.3)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.7)
     rack-cors (2.0.2)
@@ -266,6 +272,8 @@ GEM
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
@@ -303,6 +311,8 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
     securerandom (0.3.1)
     selenium-webdriver (4.25.0)
       base64 (~> 0.2)
@@ -310,6 +320,15 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.3.4)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
+    sidekiq-scheduler (5.0.6)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 6, < 8)
+      tilt (>= 1.4.0, < 3)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -324,6 +343,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.1)
     thor (1.3.2)
+    tilt (2.4.0)
     timeout (0.4.1)
     turbo-rails (2.0.10)
       actionpack (>= 6.0.0)
@@ -380,6 +400,8 @@ DEPENDENCIES
   rails (~> 7.2)
   rubocop-rails-omakase
   selenium-webdriver
+  sidekiq
+  sidekiq-scheduler
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/jobs/fetch_twitch_clips_job.rb
+++ b/app/jobs/fetch_twitch_clips_job.rb
@@ -1,0 +1,66 @@
+# app/jobs/fetch_twitch_clips_job.rb
+
+class FetchTwitchClipsJob < ApplicationJob
+  queue_as :default
+
+  require "faraday"
+  require "json"
+
+  def perform(*args)
+    client = Faraday.new(url: "https://api.twitch.tv/helix") do |faraday|
+      faraday.request :url_encoded
+      faraday.response :json, content_type: /\bjson$/
+      faraday.adapter Faraday.default_adapter
+    end
+
+    # Twitch APIエンドポイントとパラメータの設定
+    response = client.get("/clips", {
+      broadcaster_id: fetch_broadcaster_ids, # ストリーマーIDのリスト
+      first: 100 # 一度に取得するクリップ数（最大100）
+    }) do |req|
+      req.headers["Client-ID"] = Rails.application.credentials.twitch[:client_id]
+      req.headers["Authorization"] = "Bearer #{Rails.application.credentials.twitch[:access_token]}"
+    end
+
+    if response.success?
+      clips_data = response.body["data"]
+      clips_data.each do |clip|
+        Clip.find_or_create_by!(clip_id: clip["id"]) do |c|
+          c.streamer_id = fetch_streamer_id(clip["broadcaster_id"])
+          c.game_id = fetch_game_id(clip["game_id"])
+          c.language = clip["language"]
+          c.title = clip["title"]
+          c.clip_created_at = clip["created_at"]
+          c.thumbnail_url = clip["thumbnail_url"]
+          c.duration = clip["duration"].to_i
+          c.view_count = clip["view_count"]
+        end
+      end
+    else
+      Rails.logger.error "Twitch API Request Failed: #{response.status} - #{response.body}"
+    end
+  rescue StandardError => e
+    Rails.logger.error "Error fetching Twitch clips: #{e.message}"
+    # 必要に応じて通知を送る（例: Slack通知）
+  end
+
+  private
+
+  # ストリーマーIDのリストを取得または定義するメソッド
+  def fetch_broadcaster_ids
+    # 例: 特定のストリーマーのIDをデータベースから取得
+    Streamer.pluck(:streamer_id)
+  end
+
+  # broadcaster_idからstreamerの内部IDを取得するメソッド
+  def fetch_streamer_id(broadcaster_id)
+    streamer = Streamer.find_by(streamer_id: broadcaster_id)
+    streamer&.id
+  end
+
+  # game_idからゲームの内部IDを取得するメソッド
+  def fetch_game_id(game_id)
+    game = Game.find_by(game_id: game_id)
+    game&.id
+  end
+end

--- a/compose.yml
+++ b/compose.yml
@@ -1,20 +1,39 @@
+version: '3.8'
+
 services:
   db:
     image: postgres:17
     restart: always
     environment:
       TZ: Asia/Tokyo
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: twitch_clip_finder
     volumes:
-      - postgresql_data:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d twitch_clip_finder -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
+
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379" # 開発環境ではポートを公開、本番環境では内部ネットワークのみ推奨
+    volumes:
+      - redis_data:/data
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   web:
     build:
       context: .
@@ -28,12 +47,40 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      SIDEKIQ_USERNAME: ${SIDEKIQ_USERNAME}
+      SIDEKIQ_PASSWORD: ${SIDEKIQ_PASSWORD}
     ports:
       - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  worker:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    volumes:
+      - .:/myapp
+      - bundle_data:/usr/local/bundle:cached
+    environment:
+      TZ: Asia/Tokyo
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      SIDEKIQ_USERNAME: ${SIDEKIQ_USERNAME}
+      SIDEKIQ_PASSWORD: ${SIDEKIQ_PASSWORD}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
 volumes:
   bundle_data:
   postgresql_data:
   node_modules:
+  redis_data:

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module TwichClipFinder
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore
 
+    # Active JobのキューアダプターをSidekiqに設定
+    config.active_job.queue_adapter = :sidekiq
+
     config.autoload_lib(ignore: %w[assets tasks])
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,15 @@
+# config/initializers/sidekiq.rb
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV["REDIS_URL"] || "redis://redis:6379/0" }
+
+  schedule_file = "config/sidekiq.yml"
+
+  if File.exist?(schedule_file) && Sidekiq.server?
+    Sidekiq::Scheduler.reload_schedule!
+  end
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV["REDIS_URL"] || "redis://redis:6379/0" }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
+require "sidekiq/web"
+
+
 Rails.application.routes.draw do
     # Devise のルート
     devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
@@ -17,4 +20,12 @@ Rails.application.routes.draw do
 
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+
+  # 認証をハードコード
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    username == ENV["SIDEKIQ_USERNAME"] && password == ENV["SIDEKIQ_PASSWORD"]
+  end
+
+  # Sidekiq
+  mount Sidekiq::Web => "/mgmt/sidekiq"
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,13 @@
+# config/sidekiq.yml
+
+:concurrency: 5
+
+:queues:
+  - default
+  - critical
+
+:schedule:
+  fetch_twitch_clips:
+    cron: "0 * * * *"   # 毎時0分に実行
+    class: FetchTwitchClipsJob
+    queue: default

--- a/test/jobs/fetch_twitch_clips_job_test.rb
+++ b/test/jobs/fetch_twitch_clips_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FetchTwitchClipsJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要

* 変更の概要
 定期的にクリップをDBに保存するため、バックグラウンドJOB機能を実装する

## なぜこの変更をするのか

* 変更をする理由
 最初はAPIリクエストをしてクリップを取得して、表示する形式だったが5秒以上かかってしまう
そのため、DBにあらかじめ保存して表示する形式にする。それを行うために、バックグラウンドJOB機能を実装する

## やったこと

* [x] Docker Compose ファイルの更新（Redisサーバーの導入）
* [x] Sidekiqの設定
* [x] Redis接続の設定
* [x] バックグラウンドJOBの作成
* [x] 本番環境での設定

## 変更内容

* UIの変更ならスクリーンショット
* 
![Arc 2024-10-27 21 55 56](https://github.com/user-attachments/assets/8fcc6df6-e94e-44ed-a364-b0fe837dc161)

## 影響範囲

* ユーザーに影響すること
* なし
* メンバーに影響すること
  * Redisサーバーの追加
* システムに影響すること
  * Redisサーバーの追加

## どうやるのか

* 使い方
[`http`](http://localhost:3000/mgmt/sidekiq)に入る


## 備考

* その他に伝えたいこと