### PR TITLE
Feature/issue 91

### DIFF
--- a/app/controllers/playlist_clips_controller.rb
+++ b/app/controllers/playlist_clips_controller.rb
@@ -4,77 +4,60 @@ class PlaylistClipsController < ApplicationController
   def create
     # フォームから送信されたデータを取得
     playlist_clip_params = create_playlist_clip_params
-    Rails.logger.debug("フォームから送信されたデータ #{params.inspect}")
+    @playlist_name = params[:playlist_name]
+    @visibility = params[:visibility]
+    Rails.logger.debug("プレイリスト名 #{@playlist_name.inspect}")
 
     # クリップIDを取得して数値に変換
-    clip_id = playlist_clip_params[:clip_id].to_i
-    Rails.logger.debug("Converted Clip ID: #{clip_id}")
-
-    # プレイリストのIDを取得（デフォルトは空配列）
-    playlist_ids = playlist_clip_params[:playlist_ids] || []
+    clip_id = playlist_clip_params[:clip_id]
 
     # 「後で見る」が選択されているかを確認
     watch_later = playlist_clip_params[:watch_later] == "true"
+    Rails.logger.debug("「後でみる」のtrue判定 #{watch_later.inspect}")
 
-    # クリップを取得（存在しない場合は404エラー）
+    # クリップを取得
     clip = Clip.find(clip_id)
-
-    # フラッシュメッセージを格納する変数
-    success_messages = []
-    error_messages = []
-
-    # プレイリストにクリップを追加
-    if playlist_ids.any?
-      playlist_ids.each do |playlist_id|
-        playlist = current_user.playlists.find_by(id: playlist_id)
-        if playlist
-          if playlist.clips.exists?(clip.id)
-            error_messages << "プレイリスト「#{playlist.name}」には既にこのクリップが追加されています。"
-          else
-            playlist.clips << clip
-            Rails.logger.debug("Clip #{clip.id} added to playlist #{playlist.id}")
-            success_messages << "プレイリスト「#{playlist.name}」にクリップが追加されました。"
-          end
-        else
-          Rails.logger.debug("Playlist with ID #{playlist_id} not found for user #{current_user.id}")
-          error_messages << "指定されたプレイリストが見つかりませんでした。"
-        end
-      end
-    else
-      error_messages << "プレイリストが選択されていません。"
-    end
 
     # 「後で見る」の処理
     if watch_later
       watch_later_playlist = current_user.playlists.find_or_initialize_by(name: "後で見る")
+      # 新規作成の場合の処理
+      if watch_later_playlist.new_record?
+        watch_later_playlist.save
       watch_later_playlist.assign_attributes(
         user_uid: current_user.uid,
         is_watch_later: true,
-        visibility: "private"
       )
-
-      if watch_later_playlist.new_record?
-        if watch_later_playlist.save
-          Rails.logger.debug("Created new 'Watch Later' playlist: #{watch_later_playlist.inspect}")
-        else
-          error_messages << "「後で見る」プレイリストの作成に失敗しました。"
-        end
-      else
-        Rails.logger.debug("'Watch Later' playlist already exists: #{watch_later_playlist.inspect}")
       end
 
-      if watch_later_playlist.clips.exists?(clip.id)
-        error_messages << "「後で見る」プレイリストには既にこのクリップが追加されています。"
+      # 該当のクリップがすでにプレイリスト内に存在するかどうか
+      if watch_later_playlist.clips.exists?
+        flash.now[:alert] = "「後で見る」プレイリストには既にこのクリップが追加されています。"
       else
-        watch_later_playlist.clips << clip
-        Rails.logger.debug("Clip #{clip.id} added to 'Watch Later' playlist #{watch_later_playlist.id}")
-        success_messages << "クリップが「後で見る」に追加されました。"
+        watch_later_playlist.clips.push(clip)
+        flash.now[:notice] = "クリップが「後で見る」に追加されました。"
       end
     end
 
-    # 成功とエラーのメッセージをフラッシュに設定
-    flash[:notice] = success_messages.join(" ") if success_messages.any?
-    flash[:alert] = error_messages.join(" ") if error_messages.any?
+    #通常のプレイリスト作成の処理
+    unless watch_later
+      if playlist = current_user.playlists.find_or_initialize_by(name: @playlist_name)
+        if playlist.new_record?
+          playlist.save
+          Rails.logger.debug("プレイリストの詳細 #{@playlist.inspect}")
+        end
+      end
+        playlist = current_user.playlists.find_by(name: @playlist_name)
+        if playlist
+          if playlist.clips.exists?(clip.id)
+            flash.now[:alert] = "「#{playlist.name}」には既にこのクリップが追加されています。"
+          else
+            playlist.clips.push(clip)
+            flash.now[:notice] = "プレイリスト「#{playlist.name}」にクリップが追加されました。"
+          end
+        end
+      end
+
 
     # クリップ検索の準備
     search_query = params[:search_query]
@@ -105,6 +88,6 @@ class PlaylistClipsController < ApplicationController
 
   # ストロングパラメーターの定義
   def create_playlist_clip_params
-    params.permit(:clip_id, :watch_later, playlist_ids: [])
+    params.permit(:clip_id, :watch_later, :playlist_name)
   end
 end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -75,6 +75,6 @@ class PlaylistsController < ApplicationController
 
   # ストロングパラメータの定義
   def playlist_params
-    params.require(:playlist).permit(:name, :description)
+    params.require(:playlist).permit(:name)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -22,10 +22,13 @@ class SearchController < ApplicationController
     @clips = @clips.uniq
     @clips = Kaminari.paginate_array(@clips).page(params[:page]).per(60)
 
+    # プレイリストを渡してあげる
+    @playlists = current_user.playlists
+
     # 検索ワードを変数化する
     @search_query = search_query
 
     # ビューにフラグを渡して、検索結果がゲームからか配信者からかを示す
-    render partial: "search/clips", locals: { clips: @clips, search_query: @search_query }
+    render partial: "search/clips", locals: { clips: @clips, search_query: @search_query, playlists: @playlists }
   end
 end

--- a/app/models/playlist_clip.rb
+++ b/app/models/playlist_clip.rb
@@ -13,4 +13,6 @@ class PlaylistClip < ApplicationRecord
 
   # 一意性のバリデーション
   validates :clip_id, uniqueness: { scope: :playlist_id }
+
+  
 end

--- a/app/models/playlist_clip.rb
+++ b/app/models/playlist_clip.rb
@@ -13,6 +13,4 @@ class PlaylistClip < ApplicationRecord
 
   # 一意性のバリデーション
   validates :clip_id, uniqueness: { scope: :playlist_id }
-
-  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,8 +70,4 @@ class User < ApplicationRecord
   def email_changed?
     false
   end
-
-  def create_default_playlist
-    playlists.create(name: "後で見る", is_watch_later: true)
-  end
 end

--- a/app/views/playlists/_new_playlist_modal.html.erb
+++ b/app/views/playlists/_new_playlist_modal.html.erb
@@ -16,7 +16,6 @@
         <label class="label">
           <span class="label-text">説明</span>
         </label>
-        <textarea name="playlist[description]" placeholder="プレイリストの説明" class="textarea textarea-bordered"></textarea>
       </div>
 
       <div class="modal-action">

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -8,9 +8,6 @@
       <h3 class="text-lg font-bold text-purple-300">
         <%= link_to playlist.name, playlist_path(playlist), class: "hover:underline" %>
       </h3>
-      <p class="text-gray-400 text-sm mt-2">
-        <%= playlist.description.presence %>
-      </p>
       <p class="text-gray-400 text-sm mt-2">クリップ数: <%= playlist.clips.count %></p>
       <div class="mt-4 flex items-center justify-between">
         <span class="text-sm text-gray-500">いいね: <%= playlist.likes %></span>

--- a/app/views/search/_clip.html.erb
+++ b/app/views/search/_clip.html.erb
@@ -101,7 +101,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                   <path d="M12 4v16m8-8H4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                 </svg>
-                ＋新しいプレイリストを作成
+                  新しいプレイリストを作成
               </label>
             </div>
 
@@ -123,11 +123,12 @@
       <h3 class="font-bold text-lg">新しいプレイリストを作成</h3>
       <%= form_with url: playlist_clips_path, method: :post do |f| %>
         <input type="hidden" name="search_query" value="<%= @search_query %>" />
+        <input type="hidden" name="clip_id" value="<%= clip.id %>" />
         <div class="form-control mt-4">
           <label class="label">
             <span class="label-text">タイトルを入力してください</span>
           </label>
-          <input type="text" name="playlist_name" placeholder="例: マイプレイリスト" class="input input-bordered" required />
+          <%= f.text_field :playlist_name, placeholder: "例： マイプレイリスト", class: "input input-bordered" %>
         </div>
 
         <div class="form-control mt-4">

--- a/app/views/search/_clip.html.erb
+++ b/app/views/search/_clip.html.erb
@@ -128,7 +128,7 @@
           <label class="label">
             <span class="label-text">タイトルを入力してください</span>
           </label>
-          <%= f.text_field :playlist_name, placeholder: "例： マイプレイリスト", class: "input input-bordered" %>
+          <%= f.text_field :playlist_name, placeholder: "例： マイプレイリスト", class: "input input-bordered", required: true %>
         </div>
 
         <div class="form-control mt-4">

--- a/app/views/search/_clip.html.erb
+++ b/app/views/search/_clip.html.erb
@@ -69,12 +69,12 @@
         <h3 class="font-bold text-lg">動画の保存先</h3>
         <!-- モーダル内のコンテンツ -->
         <div class="py-4">
-          <!-- プレイリストのチェックボックスリスト -->
+          <!-- プレイリストのラジオボタンリスト -->
           <%= form_with url: playlist_clips_path, method: :post do |f| %>
             <input type="hidden" name="search_query" value="<%= @search_query %>" />
             <input type="hidden" name="clip_id" value="<%= clip.id %>" />
 
-            <!-- プレイリストのチェックボックスをリスト表示 -->
+            <!-- プレイリストのラジオボタンをリスト表示 -->
             <div class="form-control">
               <label class="label">
                 <span class="label-text">保存先のプレイリストを選択</span>
@@ -82,14 +82,14 @@
               <% if @playlists.present? %>
                 <% @playlists.each do |playlist| %>
                   <label class="cursor-pointer label">
-                    <input type="checkbox" name="playlist_ids[]" value="<%= playlist.id %>" class="checkbox checkbox-primary" />
+                    <input type="radio" name="playlist_name" value="<%= playlist.name %>" class="radio checkbox-primary" />
                     <span class="label-text ml-2"><%= playlist.name %></span>
                   </label>
                 <% end %>
               <% else %>
                 <!-- プレイリストがない場合、「後で見る」を表示しチェック済みにする -->
                 <label class="cursor-pointer label">
-                  <input type="checkbox" name="watch_later" value="true" class="checkbox checkbox-secondly" checked />
+                  <input type="radio" name="watch_later" value="true" class="radio radio-secondly" checked />
                   <span class="label-text ml-2">後で見る</span>
                 </label>
               <% end %>

--- a/app/views/search/_clips.html.erb
+++ b/app/views/search/_clips.html.erb
@@ -5,7 +5,7 @@
       <% clips.each do |clip| %>
         <div class="relative">
           <!-- 各クリップをレンダリング -->
-          <%= render partial: "search/clip", locals: { clip: clip, clips: clips, search_query: search_query } %>
+          <%= render partial: "search/clip", locals: { clip: clip, clips: clips, search_query: search_query, playlists: playlists } %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -79,9 +79,6 @@
             <h3 class="text-lg font-bold text-purple-500 mt-4">
               <%= link_to playlist.name, playlist_path(playlist), class: "hover:underline" %>
             </h3>
-            <p class="text-gray-500 text-sm mt-2">
-              <%= playlist.description.presence || "説明がありません。" %>
-            </p>
             <div class="mt-4 flex items-center justify-between">
               <span class="text-sm text-gray-500">いいね: <%= playlist.likes %></span>
               <%= link_to "編集", edit_playlist_path(playlist), class: "text-sm bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600" %>

--- a/db/migrate/20241128145631_remove_description_from_playlists.rb
+++ b/db/migrate/20241128145631_remove_description_from_playlists.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromPlaylists < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :playlists, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_28_145631) do
     t.index ["user_uid", "clip_id"], name: "index_favorite_clips_on_user_uid_and_clip_id", unique: true
   end
 
-  create_table "games", id: :serial, force: :cascade do |t|
+  create_table "games", force: :cascade do |t|
     t.string "name", null: false
     t.string "box_art_url"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_19_131013) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_28_145631) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_19_131013) do
     t.index ["user_uid", "clip_id"], name: "index_favorite_clips_on_user_uid_and_clip_id", unique: true
   end
 
-  create_table "games", force: :cascade do |t|
+  create_table "games", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "box_art_url"
     t.datetime "created_at", null: false
@@ -65,7 +65,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_19_131013) do
   create_table "playlists", force: :cascade do |t|
     t.string "user_uid", null: false
     t.string "name", null: false
-    t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "visibility", default: "private", null: false


### PR DESCRIPTION
## 変更の概要

* 変更の概要
プレイリスト機能を作成するため
* 関連するIssueやプルリクエスト
#91 
## なぜこの変更をするのか
現状だと、デフォルトの「後で見る」プレイリストが作成できません。デフォルトだと「非公開」のため、他のユーザーが閲覧できない。ユーザービリティの向上のために、ユーザーがプレイリスト名をつけて公開できるような機能が必要だと感じたため。

* 変更をする理由
* 前提知識がなくても分かるようにする
上記で述べたように、「後で見る」プレイリストしか現状作成できないため。

## やったこと

* [x] やったこと
    *[x] `create`アクション
    * [x] プレイリストを`playlist`テーブルに保存
      * [x] 保存できた場合：〜にクリップが保存されました
      * [x] 保存できなかった場合：〜にはすでに選択されたクリップが保存されています  