### PR TITLE
JOBによる配信者のクリップ取得ロジックの実装

### DIFF
--- a/app/services/twitch_client.rb
+++ b/app/services/twitch_client.rb
@@ -36,7 +36,7 @@ class TwitchClient
     end
   end
 
-  # 登録者数12000以上の日本配信者を取得
+  # 登録者数4万人以上の日本配信者を取得
   def fetch_japanese_streamers(max_results: 50)
     streamers = []
     pagination = nil
@@ -97,19 +97,20 @@ class TwitchClient
   end
 
   # ストリーマーのクリップを取得するメソッド
-  # broadcaster_id: ストリーマーのTwitch ID（文字列）
-  # max_results: 取得するクリップの最大数（デフォルトは20）
-  def fetch_clips(broadcaster_id, max_results: 5)
+  # 200のクリップを取得する
+  def fetch_clips(broadcaster_id, max_results: 200)
     clips = []
     pagination = nil
 
     loop do
       remaining = max_results - clips.size
+      # ２００のクリップを取得したらループを終了する
       break if remaining <= 0
 
       params = {
         broadcaster_id: broadcaster_id,
-        first: [ remaining, 40 ].min
+        # APIでリクエストできる最大の数の100件をリクエストする
+        first: [ remaining, 100 ].min
       }
       params[:after] = pagination if pagination
 
@@ -117,9 +118,6 @@ class TwitchClient
         req.headers["Client-ID"] = @client_id
         req.headers["Authorization"] = "Bearer #{@access_token}"
       end
-
-      Rails.logger.debug "Received response status: #{response.status}"
-      Rails.logger.debug "Received response body: #{response.body}"
 
       if response.success?
         data = response.body["data"]
@@ -135,7 +133,6 @@ class TwitchClient
     clips.first(max_results)
   rescue StandardError => e
     Rails.logger.error "TwitchClient Error: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
     []
   end
 

--- a/app/services/twitch_client.rb
+++ b/app/services/twitch_client.rb
@@ -127,39 +127,35 @@ class TwitchClient
           pagination = response.body["pagination"]["cursor"]
           break if pagination.nil? || data.empty?
         else
-          Rails.logger.error "Twitch API Error: #{response.status} - #{response.body['message']}"
           break
         end
+        clips.first(max_results)
       end
 
-      clips.first(max_results)
-    rescue StandardError => e
-      Rails.logger.error "TwitchClient Error: #{e.message}"
-      []
-    end
-  else
-    loop do
-      now = Time.now
-      yesterday = now - 1.day.ago
+    else
+      loop do
+        now = Time.now
+        yesterday = now - 1.day.ago
 
-      params = {
-        broadcaster_id: broadcaster_id,
-        started_at: yesterday,
-        ended_at: now,
-        first: [100].min
-      }
+        params = {
+          broadcaster_id: broadcaster_id,
+          started_at: yesterday,
+          ended_at: now,
+          first: [ 100 ].min
+        }
 
-      response = @connection.get("clips", params) do |req|
-        req.headers["Client-ID"] = @client_id
-        req.headers["Authorization"] = "Bearer #{@access_token}"
-      end
+        response = @connection.get("clips", params) do |req|
+          req.headers["Client-ID"] = @client_id
+          req.headers["Authorization"] = "Bearer #{@access_token}"
+        end
 
-      if response.success?
-        data = response.body["data"]
-        clips += data
-        break
-      else
-        break
+        if response.success?
+          data = response.body["data"]
+          clips += data
+          break
+        else
+          break
+        end
       end
     end
   end
@@ -209,5 +205,5 @@ class TwitchClient
 
   private
 
-  # 
+  #
 end


### PR DESCRIPTION
## 変更の概要
#98 JOBでのクリップ取得機能

## なぜこの変更をするのか
現在、配信者のクリップ取得数は20となっており、サービスを運営するにあたり不足しています。
そのため、200のクリップを取得するように修正しました。
また、毎回各配信者のクリップを200取得するのは効率が悪いため、クリップが存在する配信者は過去1日分のクリップを取得するように実装しました。

## やったこと

* [x] やったこと
 * [ ] 配信者IDをもとに検索
   * [ ] クリップが存在する場合：過去1日分のクリップを取得
   * [ ] クリップが存在しない場合：300クリップの取得

## 影響範囲

* ユーザーに影響すること
クリップ数の増加
* メンバーに影響すること
JOBのクリップ取得ロジックの変更