### PR TITLE
リフレッシュトークンのエラーの解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ group :development, :test do
   # テスト用
   gem "rspec-rails"
   gem "factory_bot_rails"
+
+  # Lint用
+  gem "solargraph"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.3.0)
@@ -118,6 +119,7 @@ GEM
       dotenv (= 3.1.4)
       railties (>= 6.1)
     drb (2.2.1)
+    e2mmap (0.1.0)
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
@@ -144,6 +146,7 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.6.0)
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -164,6 +167,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.23.1)
@@ -284,6 +291,7 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
+    rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis-client (0.22.2)
@@ -294,6 +302,8 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -363,6 +373,22 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    solargraph (0.50.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (~> 2.0)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      rbs (~> 2.0)
+      reverse_markdown (~> 2.0)
+      rubocop (~> 1.38)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -399,6 +425,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -437,6 +464,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq
   sidekiq-scheduler
+  solargraph
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,22 +18,27 @@ class ApplicationController < ActionController::Base
   end
 
   # フォローリストをAPI経由で取得
-  # フォローリストを取得するメソッド (Faradayを使用)
   def fetch_followed_channels(user_id)
+    # ClientIDを取得
     client_id = ENV["TWITCH_CLIENT_ID"]
+    # 現在のユーザーのアクセストークンを取得する
     access_token = current_user.access_token
 
     begin
+      # Faradayを使用してTwitchAPIにリクエストを送る
       response = Faraday.get("https://api.twitch.tv/helix/channels/followed") do |req|
         req.params["user_id"] = current_user.uid
         req.headers["Authorization"] = "Bearer #{access_token}"
         req.headers["Client-ID"] = client_id
       end
 
+      # もし成功したら
       if response.success?
+        # フォローリストが返ってくる
         follows = JSON.parse(response.body)["data"]
         user_ids = follows.map { |follow| follow["broadcaster_id"] }
 
+        # ユーザー情報が返ってkくる
         users_info = fetch_users_info(access_token, user_ids)
         follows.map do |follow|
           user_info = users_info.find { |user| user["id"] == follow["broadcaster_id"] }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,13 @@
 class UsersController < ApplicationController
   # TOPページに遷移
+
   def index
     if current_user.present?
-      # トークンの有効期限が存在し、期限が切れている場合はリフレッシュ
+      Rails.logger.debug "現在のユーザー: #{current_user}"
+      # トークンの期限が存在し、期限が切れている場合はリフレッシュ
       if current_user.token_expires_at.present? && current_user.token_expires_at < Time.now
         refresh_access_token(current_user)
       end
-
-      user_id = current_user.id
-      @followed_channels = fetch_followed_channels(user_id)
-    else
-      @followed_channels = nil
     end
   end
 
@@ -24,6 +21,7 @@ class UsersController < ApplicationController
         grant_type: "refresh_token"
       }
       req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+      Rails.logger.debug "リクエストの内容: #{req.headers}"
     end
 
     if response.success?
@@ -34,7 +32,7 @@ class UsersController < ApplicationController
         token_expires_at: Time.now + token_data["expires_in"].to_i.seconds
       )
     else
-      redirect_to root_path, alert: "アクセストークンの更新に失敗しました。"
+      Rails.logger.debug "リクエストに失敗しました"
     end
   end
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -47,8 +47,8 @@ en:
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
     sessions:
       signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
+      signed_out: "ログアウトしました"
+      already_signed_out: "ログアウトしました"
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."


### PR DESCRIPTION
## 変更の概要

* 変更の概要
リフレッシュトークンが取得できない場合、root_pathにリダイレクトさせるのではなく、アラートメッセージを表示するのみに変更した。
* 関連するIssueやプルリクエスト
#106 
## なぜこの変更をするのか
現在、リフレッシュトークンが現在日付より過去日であった場合には、再取得するようにしていた。しかし、再取得ができずroot_pahtに無限リダイレクトしていたので応急処置としてエラーメッセージを表示するのみにとどめた。

## やったこと

* [x] やったこと
  * [x] `UserController`の`get_reflesh_token`メソッドのelseの変更

