### PR TITLE
Feature/issue 114

### DIFF
--- a/app/jobs/fetch_twitch_clips_job.rb
+++ b/app/jobs/fetch_twitch_clips_job.rb
@@ -12,11 +12,8 @@ class FetchTwitchClipsJob < ApplicationJob
   private
 
   def get_clips(client, streamer)
-    Rails.logger.info "開始: 配信者 #{streamer.display_name} (ID: #{streamer.streamer_id})"
-
     # クリップを取得
     clips = client.fetch_clips(streamer.streamer_id, max_results: 200)
-    Rails.logger.info "取得クリップ数: #{clips.size} (配信者: #{streamer.display_name})"
 
     # クリップを保存
     save_clips(clips, streamer)

--- a/app/jobs/fetch_twitch_clips_job.rb
+++ b/app/jobs/fetch_twitch_clips_job.rb
@@ -13,7 +13,7 @@ class FetchTwitchClipsJob < ApplicationJob
 
   def get_clips(client, streamer)
     # クリップを取得
-    clips = client.fetch_clips(streamer.streamer_id, max_results: 200)
+    clips = client.fetch_clips(streamer.streamer_id, 200)
 
     # クリップを保存
     save_clips(clips, streamer)
@@ -31,9 +31,6 @@ class FetchTwitchClipsJob < ApplicationJob
   end
 
   def save_clip(clip_data, streamer)
-    Rails.logger.debug "保存するクリップ: #{clip_data}"
-    Rails.logger.debug "保存する配信者ID: #{streamer.streamer_id}"
-
     game = Game.find_or_create_by(game_id: clip_data["game_id"]) do |g|
       game_data = client.fetch_game(clip_data["game_id"])
       if game_data
@@ -66,6 +63,5 @@ class FetchTwitchClipsJob < ApplicationJob
     end
   rescue StandardError => e
     Rails.logger.error "クリップ保存中のエラー: #{clip_data['id']} - #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,12 @@
+:concurrency: 5
+
+:queues:
+  - default
+  - critical
+
+scheduler:
+  schedule:
+    fetch_twitch_clips_job:
+      cron: "0 0 * * *"   # 毎日0時に実行
+      class: FetchTwitchClipsJob
+      queue: default

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -1,0 +1,6 @@
+scheduler:
+  schedule:
+    fetch_twitch_clips_job:
+      cron: "0 0 * * *"   # 毎日0時に実行
+      class: FetchTwitchClipsJob
+      queue: default


### PR DESCRIPTION
## 変更の概要

* 過去1日分のクリップを1日おきに取得できるようにするため
* #114 

## なぜこの変更をするのか

* 変更をする理由
* 前提知識がなくても分かるようにする
* 現在、200のクリップのみ収納されています。しかし、現在の取得方法が人気が高い200のクリップのみを取得していてリアルタイム性に欠けると考えています。そのため、過去1日分のクリップを取得する実装を行いました。

## やったこと

* [x] やったこと
  * [x]  配信者がクリップを持っているかどうかを判定する
  * [x] 持っている場合：過去1日分のクリップを取得する
  * [x] 持っていない場合：全クリップを取得する

## 変更内容
今までは、200のクリップを取得するのみのbatch処理だったが、今回の実装で過去1日分のクリップを取得する処理が加わった。
## 影響範囲

* ユーザーに影響すること
* 特になし
* メンバーに影響すること
* 過去1日分のクリップを取得する処理が加わった
* システムに影響すること
* 過去1日分のクリップを取得する処理が加わった