### PR TITLE
クリップ編集機能　実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem "sidekiq"
 # Sidekiq Schedulerをジョブのスケジューリングに使用
 gem "sidekiq-scheduler"
 
+# 日本語化
+gem "rails-i18n"
+
 # 検索用
 gem "ransack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2)
       actionpack (= 7.2.2)
       activesupport (= 7.2.2)
@@ -458,6 +461,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 7.2)
+  rails-i18n
   ransack
   rspec-rails
   rubocop-rails-omakase

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -3,7 +3,7 @@ class PlaylistsController < ApplicationController
   # ユーザーが認証されていることを確認
   before_action :authenticate_user!
   # 特定のアクション前にプレイリストを設定
-  before_action :set_playlist, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_playlist, only: [ :show, :update, :destroy ]
 
   # 明示的に application レイアウトを使用
   layout "application"
@@ -39,19 +39,19 @@ class PlaylistsController < ApplicationController
 
   # プレイリストを更新
   def update
-    if @playlist.update(playlist_params)
-      redirect_to @playlist
-    else
-      render :edit
-    end
+    Rails.logger.debug "プレイリストの中身: #{@playlist.inspect}"
+    @playlist.update(playlist_params)
+      respond_to do |format|
+        format.html { redirect_to request.referer, notice: "#{@playlist.title}を更新しました" }
+      end
   end
 
   # プレイリストを削除
   def destroy
     @playlist.destroy
     respond_to do |format|
-      format.turbo_stream { flash.now[:notice] = "#{@playlist.name}を削除しました" }
-      format.html { redirect_to show_path, notice: "#{@playlist.name}を削除しました", status: :see_other }
+      format.turbo_stream { flash.now[:notice] = "#{@playlist.title}を削除しました" }
+      format.html { redirect_to show_path, notice: "#{@playlist.title}を削除しました", status: :see_other }
     end
   end
 
@@ -61,13 +61,11 @@ class PlaylistsController < ApplicationController
   def set_playlist
     # 現在のユーザーが所有するプレイリストのみを検索
     @playlist = current_user.playlists.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    # プレイリストが見つからない場合はプレイリスト一覧ページにリダイレクト
-    redirect_to "users/show"
+    @playlists = current_user.playlists.order(:id)
   end
 
   # ストロングパラメータの定義
   def playlist_params
-    params.require(:playlist).permit(:name)
+    params.require(:playlist).permit(:title, :visibility, :id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,5 +41,7 @@ class UsersController < ApplicationController
   def show
     # プレイリストを取得
     @playlists = current_user.playlists
+    @playlists = @playlists.order(:id)
+    @playlists = Kaminari.paginate_array(@playlists).page(params[:page]).per(9)
   end
 end

--- a/app/javascript/controllers/form_validation_controller.js
+++ b/app/javascript/controllers/form_validation_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["input", "errorMessage", "lengthErrorMessage", "charCount"]; // charCount を追加
+
+  connect() {
+    console.log("FormValidationController connected");
+  }
+
+  validate(event) {
+    const inputValue = this.inputTarget.value.trim(); // 入力値の前後の空白を削除
+
+    // 入力が空白の場合
+    if (inputValue === "") {
+      event.preventDefault(); // フォーム送信を阻止
+      this.errorMessageTarget.classList.remove("hidden"); // 必須エラーメッセージを表示
+      this.lengthErrorMessageTarget.classList.add("hidden"); // 長さエラーメッセージを非表示
+      this.inputTarget.classList.add("border-red-500"); // 入力枠を赤に変更
+    } 
+    // 入力が30文字を超える場合
+    else if (inputValue.length > 30) {
+      event.preventDefault(); // フォーム送信を阻止
+      this.lengthErrorMessageTarget.classList.remove("hidden"); // 長さエラーメッセージを表示
+      this.errorMessageTarget.classList.add("hidden"); // 必須エラーメッセージを非表示
+      this.inputTarget.classList.add("border-red-500"); // 入力枠を赤に変更
+    } 
+    // 問題がない場合
+    else {
+      this.errorMessageTarget.classList.add("hidden"); // 必須エラーメッセージを非表示
+      this.lengthErrorMessageTarget.classList.add("hidden"); // 長さエラーメッセージを非表示
+      this.inputTarget.classList.remove("border-red-500"); // 赤枠を解除
+    }
+    this.countCharacters(); // 文字数をカウントして表示
+  }
+
+  countCharacters() {
+    const charCount = this.inputTarget.value.length; // 現在の文字数を取得
+    this.charCountTarget.textContent = `${charCount}/30`; // 文字数表示を更新
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("clip-loader", ClipLoaderController)
 import FlashController from "./flash_controller"
 application.register("flash", FlashController)
 
+import FormValidationController from "./form_validation_controller"
+application.register("form-validation", FormValidationController)
+
 import GameSearchController from "./game_search_controller"
 application.register("game-search", GameSearchController)
 

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -13,7 +13,8 @@ class Playlist < ApplicationRecord
    scope :private_playlists, -> { where(visibility: "private") }
 
   # バリデーション
-  validates :name, presence: true
+  validates :title, presence: true
+  validates :title, length: { in: 1..30 }
 
   # カラムの値を簡単に操作するメソッドを追加
   def increment_likes

--- a/app/views/playlists/_clip.html.erb
+++ b/app/views/playlists/_clip.html.erb
@@ -2,24 +2,8 @@
 <div class="clip-container p-4 relative rounded-lg border-b-4 border-gray-200 flex flex-col justify-between">
   <!-- 動画部分 -->
   <figure class="relative" data-controller="video">
-    <img
-      data-video-target="thumbnail"
-      src="<%= clip.thumbnail_url.gsub('%{width}x%{height}', '1280x720') %>"
-      alt="<%= clip.title %>"
-      class="w-full h-auto cursor-pointer"
-      style="height: 300px;"
-      data-action="click->video#showVideo"
-      loading="lazy"
-    />
-    <iframe
-      data-video-target="iframe"
-      src="https://clips.twitch.tv/embed?clip=<%= clip.clip_id %>&parent=<%= ENV['TWITCH_PARENT_URL'] %>"
-      scrolling="no"
-      allowfullscreen="true"
-      class="w-full h-auto"
-      style="max-width: 100%; height: 300px; display: none;"
-      loading="lazy"
-    ></iframe>
+    <img data-video-target="thumbnail" src="<%= clip.thumbnail_url.gsub('%{width}x%{height}', '1280x720') %>" alt="<%= clip.title %>" class="w-full h-auto cursor-pointer" style="height: 300px;" data-action="click->video#showVideo" loading="lazy" />
+    <iframe data-video-target="iframe" src="https://clips.twitch.tv/embed?clip=<%= clip.clip_id %>&parent=<%= ENV['TWITCH_PARENT_URL'] %>" scrolling="no" allowfullscreen="true" class="w-full h-auto" style="max-width: 100%; height: 300px; display: none;" loading="lazy"></iframe>
   </figure>
 
   <div class="pl-4 w-full max-w-full">
@@ -31,12 +15,7 @@
     <div class="flex items-start">
       <!-- 配信者アイコンと名前 -->
       <%= link_to search_path(q: clip.streamer.display_name), data: { turbo_frame: "clips" } do %>
-        <img
-          src="<%= clip.streamer.profile_image_url ? clip.streamer.profile_image_url.gsub('{width}x{height}', '100x100') : 'default-avatar-url.jpg' %>"
-          alt="<%= clip.streamer.display_name %>"
-          class="w-10 h-10 rounded-full object-cover mr-4"
-          loading="lazy"
-        />
+      <img src="<%= clip.streamer.profile_image_url ? clip.streamer.profile_image_url.gsub('{width}x{height}', '100x100') : 'default-avatar-url.jpg' %>" alt="<%= clip.streamer.display_name %>" class="w-10 h-10 rounded-full object-cover mr-4" loading="lazy" />
       <% end %>
       <div>
         <!-- 配信者名 -->
@@ -71,45 +50,47 @@
         <div class="py-4">
           <!-- プレイリストのチェックボックスリスト -->
           <%= form_with url: playlist_clips_path, method: :post do |f| %>
-            <input type="hidden" name="search_query" value="<%= @search_query %>" />
-            <input type="hidden" name="clip_id" value="<%= clip.id %>" />
+          <input type="hidden" name="search_query" value="<%= @search_query %>" />
+          <input type="hidden" name="clip_id" value="<%= clip.id %>" />
 
-            <!-- プレイリストのチェックボックスをリスト表示 -->
-            <div class="form-control">
-              <label class="label">
-                <span class="label-text">保存先のプレイリストを選択</span>
-              </label>
-              <% if @playlists.present? %>
-                <% @playlists.each do |playlist| %>
-                  <label class="cursor-pointer label">
-                    <input type="checkbox" name="playlist_ids[]" value="<%= playlist.id %>" class="checkbox checkbox-primary" />
-                    <span class="label-text ml-2"><%= playlist.name %></span>
-                  </label>
-                <% end %>
-              <% else %>
-                <!-- プレイリストがない場合、「後で見る」を表示しチェック済みにする -->
-                <label class="cursor-pointer label">
-                  <input type="checkbox" name="watch_later" value="true" class="checkbox checkbox-secondly" checked />
-                  <span class="label-text ml-2">後で見る</span>
-                </label>
-              <% end %>
-            </div>
+          <!-- プレイリストのチェックボックスをリスト表示 -->
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text">保存先のプレイリストを選択</span>
+            </label>
+            <% if @playlists.present? %>
+            <% @playlists.each do |playlist| %>
+            <label class="cursor-pointer label">
+              <input type="checkbox" name="watch_later" value="true" class="checkbox checkbox-secondly" checked />
+              <span class="label-text ml-2">後で見る</span>
+              <input type="checkbox" name="playlist_ids[]" value="<%= playlist.id %>" class="checkbox checkbox-primary" />
+              <span class="label-text ml-2"><%= playlist.name %></span>
+            </label>
+            <% end %>
+            <% else %>
+            <!-- プレイリストがない場合、「後で見る」を表示しチェック済みにする -->
+            <label class="cursor-pointer label">
+              <input type="checkbox" name="watch_later" value="true" class="checkbox checkbox-secondly" checked />
+              <span class="label-text ml-2">後で見る</span>
+            </label>
+            <% end %>
+          </div>
 
-            <!-- 「新しいプレイリストを作成」 -->
-            <div class="mt-4">
-              <label for="new-playlist-modal" class="btn btn-secondary flex items-center justify-center w-full">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                  <path d="M12 4v16m8-8H4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                </svg>
-                ＋新しいプレイリストを作成
-              </label>
-            </div>
+          <!-- 「新しいプレイリストを作成」 -->
+          <div class="mt-4">
+            <label for="new-playlist-modal" class="btn btn-secondary flex items-center justify-center w-full">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path d="M12 4v16m8-8H4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              ＋新しいプレイリストを作成
+            </label>
+          </div>
 
-            <!-- 保存ボタン -->
-            <div class="modal-action">
-              <button type="submit" class="btn btn-primary">保存</button>
-              <label for="playlist-modal-<%= clip.id %>" class="btn">キャンセル</label>
-            </div>
+          <!-- 保存ボタン -->
+          <div class="modal-action">
+            <button type="submit" class="btn btn-primary">保存</button>
+            <label for="playlist-modal-<%= clip.id %>" class="btn">キャンセル</label>
+          </div>
           <% end %>
         </div>
       </div>
@@ -122,28 +103,24 @@
     <div class="modal-box rounded-lg shadow-lg">
       <h3 class="font-bold text-lg">新しいプレイリストを作成</h3>
       <%= form_with url: playlist_clips_path, method: :post do |f| %>
-        <input type="hidden" name="search_query" value="<%= @search_query %>" />
-        <div class="form-control mt-4">
-          <label class="label">
-            <span class="label-text">タイトルを入力してください</span>
-          </label>
-          <input type="text" name="playlist_name" placeholder="例: マイプレイリスト" class="input input-bordered" required />
-        </div>
+      <input type="hidden" name="search_query" value="<%= @search_query %>" />
+      <div class="form-control mt-4">
+        <label class="label">
+          <span class="label-text">タイトルを入力してください</span>
+        </label>
+        <input type="text" name="playlist_name" placeholder="例: マイプレイリスト" class="input input-bordered" required />
+      </div>
 
-        <div class="form-control mt-4">
-          <label class="label">
-            <span class="label-text">公開設定</span>
-          </label>
-          <select name="visibility" class="select select-bordered">
-            <option value="private" selected>非公開</option>
-            <option value="public">公開</option>
-          </select>
-        </div>
+      <!-- 公開設定 -->
+      <div class="form-control mt-4">
+        <%= form.label :visibility, "公開設定", class: "label-text block text-sm font-medium text-black" %>
+        <%= form.select :visibility, [["非公開", "private"], ["公開", "public"]], { selected: form.object.visibility }, class: "select select-bordered" %>
+      </div>
 
-        <div class="modal-action">
-          <label for="new-playlist-modal" class="btn">キャンセル</label>
-          <button type="submit" class="btn btn-primary">作成</button>
-        </div>
+      <div class="modal-action">
+        <label for="new-playlist-modal" class="btn">キャンセル</label>
+        <button type="submit" class="btn btn-primary">作成</button>
+      </div>
       <% end %>
     </div>
   </div>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -23,7 +23,7 @@
 
   <!-- クリップ一覧 -->
   <div class="flex-1 bg-gray-100 p-4 rounded-lg mx-4 mt-4 overflow-y-auto" style="max-height: 50vh;">
-    <h2 class="text-lg font-bold text-black mb-4"><%= @playlist.name %></h2>
+    <h2 class="text-lg font-bold text-black mb-4"><%= @playlist.title %></h2>
     <ul class="space-y-4">
       <% @clips.each do |clip| %>
       <li class="flex items-center bg-gray-200 p-3 rounded-lg hover:bg-gray-300 transition">

--- a/app/views/search/_clip.html.erb
+++ b/app/views/search/_clip.html.erb
@@ -2,24 +2,8 @@
 <div class="clip-container p-4 relative rounded-lg border-b-4 border-gray-200 flex flex-col justify-between">
   <!-- 動画部分 -->
   <figure class="relative" data-controller="video">
-    <img
-      data-video-target="thumbnail"
-      src="<%= clip.thumbnail_url.gsub('%{width}x%{height}', '1280x720') %>"
-      alt="<%= clip.title %>"
-      class="w-full h-auto cursor-pointer"
-      style="height: 300px;"
-      data-action="click->video#showVideo"
-      loading="lazy"
-    />
-    <iframe
-      data-video-target="iframe"
-      src="https://clips.twitch.tv/embed?clip=<%= clip.clip_id %>&parent=<%= ENV['TWITCH_PARENT_URL'] %>"
-      scrolling="no"
-      allowfullscreen="true"
-      class="w-full h-auto"
-      style="max-width: 100%; height: 300px; display: none;"
-      loading="lazy"
-    ></iframe>
+    <img data-video-target="thumbnail" src="<%= clip.thumbnail_url.gsub('%{width}x%{height}', '1280x720') %>" alt="<%= clip.title %>" class="w-full h-auto cursor-pointer" style="height: 300px;" data-action="click->video#showVideo" loading="lazy" />
+    <iframe data-video-target="iframe" src="https://clips.twitch.tv/embed?clip=<%= clip.clip_id %>&parent=<%= ENV['TWITCH_PARENT_URL'] %>" scrolling="no" allowfullscreen="true" class="w-full h-auto" style="max-width: 100%; height: 300px; display: none;" loading="lazy"></iframe>
   </figure>
 
   <div class="pl-4 w-full max-w-full">
@@ -31,12 +15,7 @@
     <div class="flex items-start">
       <!-- 配信者アイコンと名前 -->
       <%= link_to search_path(q: clip.streamer.display_name), data: { turbo_frame: "clips" } do %>
-        <img
-          src="<%= clip.streamer.profile_image_url ? clip.streamer.profile_image_url.gsub('{width}x{height}', '100x100') : 'default-avatar-url.jpg' %>"
-          alt="<%= clip.streamer.display_name %>"
-          class="w-10 h-10 rounded-full object-cover mr-4"
-          loading="lazy"
-        />
+      <img src="<%= clip.streamer.profile_image_url ? clip.streamer.profile_image_url.gsub('{width}x{height}', '100x100') : 'default-avatar-url.jpg' %>" alt="<%= clip.streamer.display_name %>" class="w-10 h-10 rounded-full object-cover mr-4" loading="lazy" />
       <% end %>
       <div>
         <!-- 配信者名 -->
@@ -73,45 +52,45 @@
         <div class="py-4">
           <!-- プレイリストのラジオボタンリスト -->
           <%= form_with url: playlist_clips_path, method: :post do |f| %>
-            <input type="hidden" name="search_query" value="<%= @search_query %>" />
-            <input type="hidden" name="clip_id" value="<%= clip.id %>" />
+          <input type="hidden" name="search_query" value="<%= @search_query %>" />
+          <input type="hidden" name="clip_id" value="<%= clip.id %>" />
 
-            <!-- プレイリストのラジオボタンをリスト表示 -->
-            <div class="form-control">
-              <label class="label">
-                <span class="label-text">保存先のプレイリストを選択</span>
-              </label>
-              <% if @playlists.present? %>
-                <% @playlists.each do |playlist| %>
-                  <label class="cursor-pointer label">
-                    <input type="radio" name="playlist_name" value="<%= playlist.name %>" class="radio checkbox-primary" />
-                    <span class="label-text ml-2"><%= playlist.name %></span>
-                  </label>
-                <% end %>
-              <% else %>
-                <!-- プレイリストがない場合、「後で見る」を表示しチェック済みにする -->
-                <label class="cursor-pointer label">
-                  <input type="radio" name="watch_later" value="true" class="radio radio-secondly" checked />
-                  <span class="label-text ml-2">後で見る</span>
-                </label>
-              <% end %>
-            </div>
+          <!-- プレイリストのラジオボタンをリスト表示 -->
+          <div class="form-control">
+            <label class="label">
+              <span class="label-text">保存先のプレイリストを選択</span>
+            </label>
+            <% if @playlists.present? %>
+            <% @playlists.each do |playlist| %>
+            <label class="cursor-pointer label">
+              <input type="radio" name="playlist_title" value="<%= playlist.title %>" class="radio checkbox-primary" />
+              <span class="label-text ml-2"><%= playlist.title %></span>
+            </label>
+            <% end %>
+            <% else %>
+            <!-- プレイリストがない場合、「後で見る」を表示しチェック済みにする -->
+            <label class="cursor-pointer label">
+              <input type="radio" name="watch_later" value="true" class="radio radio-secondly" checked />
+              <span class="label-text ml-2">後で見る</span>
+            </label>
+            <% end %>
+          </div>
 
-            <!-- 「新しいプレイリストを作成」 -->
-            <div class="mt-4">
-              <label for="new-playlist-modal" class="btn btn-secondary flex items-center justify-center w-full">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-                  <path d="M12 4v16m8-8H4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
-                </svg>
-                  新しいプレイリストを作成
-              </label>
-            </div>
+          <!-- 「新しいプレイリストを作成」 -->
+          <div class="mt-4">
+            <label for="new-playlist-modal" class="btn btn-secondary flex items-center justify-center w-full">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <path d="M12 4v16m8-8H4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              新しいプレイリストを作成
+            </label>
+          </div>
 
-            <!-- 保存ボタン -->
-            <div class="modal-action">
-              <button type="submit" class="btn btn-primary">保存</button>
-              <label for="playlist-modal-<%= clip.id %>" class="btn">キャンセル</label>
-            </div>
+          <!-- 保存ボタン -->
+          <div class="modal-action">
+            <button type="submit" class="btn btn-primary">保存</button>
+            <label for="playlist-modal-<%= clip.id %>" class="btn">キャンセル</label>
+          </div>
           <% end %>
         </div>
       </div>
@@ -124,29 +103,24 @@
     <div class="modal-box rounded-lg shadow-lg">
       <h3 class="font-bold text-lg">新しいプレイリストを作成</h3>
       <%= form_with url: playlist_clips_path, method: :post do |f| %>
-        <input type="hidden" name="search_query" value="<%= @search_query %>" />
-        <input type="hidden" name="clip_id" value="<%= clip.id %>" />
-        <div class="form-control mt-4">
-          <label class="label">
-            <span class="label-text">タイトルを入力してください</span>
-          </label>
-          <%= f.text_field :playlist_name, placeholder: "例： マイプレイリスト", class: "input input-bordered", required: true %>
-        </div>
+      <input type="hidden" name="search_query" value="<%= @search_query %>" />
+      <input type="hidden" name="clip_id" value="<%= clip.id %>" />
+      <div class="form-control mt-4">
+        <label class="label">
+          <span class="label-text">タイトルを入力してください</span>
+        </label>
+        <%= f.text_field :playlist_title, placeholder: "例： マイプレイリスト", class: "input input-bordered", required: true %>
+      </div>
 
-        <div class="form-control mt-4">
-          <label class="label">
-            <span class="label-text">公開設定</span>
-          </label>
-          <select name="visibility" class="select select-bordered">
-            <option value="private" selected>非公開</option>
-            <option value="public">公開</option>
-          </select>
-        </div>
-
-        <div class="modal-action">
-          <label for="new-playlist-modal" class="btn">キャンセル</label>
-          <button type="submit" class="btn btn-primary">作成</button>
-        </div>
+      <!-- 公開設定 -->
+      <div class="form-control mt-4">
+        <%= f.label :visibility, "公開設定", class: "label-text block text-sm font-medium text-black" %>
+        <%= f.select :visibility, options_for_select([["非公開", "private"], ["公開", "public"]]), {}, class: "select select-bordered" %>
+      </div>
+      <div class="modal-action">
+        <label for="new-playlist-modal" class="btn">キャンセル</label>
+        <button type="submit" class="btn btn-primary">作成</button>
+      </div>
       <% end %>
     </div>
   </div>

--- a/app/views/users/_modal.html.erb
+++ b/app/views/users/_modal.html.erb
@@ -1,0 +1,53 @@
+<!-- 編集モーダル -->
+<input type="checkbox" id="edit-modal-<%= playlist.id %>" class="modal-toggle" />
+<div class="modal flex justify-center items-center fixed inset-0 bg-white z-50">
+  <div class="modal-box bg-white rounded-lg shadow-lg max-w-md w-full text-black">
+    <!-- モーダルヘッダー -->
+    <div class="flex justify-between items-center">
+      <h3 class="font-bold text-lg text-black">プレイリストの編集</h3>
+      <!-- 「X」ボタン -->
+      <label for="edit-modal-<%= playlist.id %>" class="btn btn-sm btn-circle">✕</label>
+    </div>
+    <!-- モーダルボディ -->
+    <div class="p-6 space-y-6" data-controller="form-validation">
+      <%= form_with(model: playlist, url: playlist_path(playlist), method: :patch, data: { turbo: false }) do |form| %>
+      <!-- プレイリスト画像 -->
+      <%= image_tag playlist.clips.first&.thumbnail_url, alt: "サムネイル", class: "rounded-lg w-full h-32 object-cover" %>
+      <!-- プレイリスト名 -->
+      <div>
+        <%= form.label :title, "プレイリスト名", class: "block text-sm font-medium text-black" %>
+        <%= form.text_field :title, 
+          value: playlist.title, 
+          class: "mt-1 block w-full bg-white border border-gray-300 rounded-md shadow-sm focus:ring-purple-500 focus:border-purple-500 text-black", 
+          data: { form_validation_target: "input", action: "input->form-validation#validate" }, 
+          required: "required" %>
+        <!-- 必須エラーメッセージ -->
+        <div class="text-red-500 text-sm hidden mt-1" data-form-validation-target="errorMessage">
+          プレイリスト名を入力してください。
+        </div>
+        <!-- 長さエラーメッセージ -->
+        <div class="text-red-500 text-sm hidden mt-1" data-form-validation-target="lengthErrorMessage">
+          プレイリスト名が長すぎます。
+        </div>
+        <div class="text-gray-500 text-sm mt-1" data-form-validation-target="charCount">
+          0/30
+        </div>
+      </div>
+      <!-- 公開設定 -->
+      <div class="form-control mt-4 bg-white">
+        <%= form.label :visibility, "公開設定", class: "label-text block text-sm font-medium text-black" %>
+        <%= form.select :visibility, [["非公開", "private"], ["公開", "public"]], 
+        { selected: form.object.visibility }, 
+        class: "select select-bordered bg-white text-black" %>
+      </div>
+
+      <!-- モーダルフッター内にフォームの送信ボタンを配置 -->
+      <div class="flex justify-end space-x-2 mt-4">
+        <%= form.submit "変更", 
+    class: "btn bg-purple-600 hover:bg-purple-700 text-white border-none", 
+    data: { action: "form-validation#validate" } %>
+      </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_playlist.html.erb
+++ b/app/views/users/_playlist.html.erb
@@ -1,21 +1,63 @@
-<!-- プレイリストカード -->
 <% if playlist.present? %>
-<div class="bg-white p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow" , id="<%= dom_id(playlist) %>">
+<div class="bg-white p-4 rounded-lg" id="<%= dom_id(playlist) %>">
+  <!-- プレイリストへのリンク -->
+  <%= link_to playlist_path(playlist), class: "block" do %>
   <div class="relative">
+    <!-- サムネイル画像 -->
     <%= image_tag playlist.clips.first&.thumbnail_url, alt: "サムネイル", class: "rounded-lg w-full h-32 object-cover" %>
+    <!-- クリップ数表示 -->
     <span class="absolute bottom-2 right-2 bg-black bg-opacity-50 text-white text-xs px-2 py-1 rounded">
       クリップ数: <%= playlist.clips.count %>
     </span>
   </div>
-  <h3 class="text-lg font-bold text-purple-500 mt-4">
-    <%= link_to playlist.name, playlist_path(playlist), class: "hover:underline" %>
-  </h3>
-  <div class="mt-4 flex items-center justify-between">
-    <span class="text-sm text-gray-500">いいね: </span>
-    <%= link_to "編集", edit_playlist_path(playlist), class: "text-sm bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600" %>
-    <%= link_to "削除", playlist_path(playlist), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", turbo_frame: "_top" }, class: "text-sm bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600" %>
+
+
+  <!-- タイトルと三点リーダーアイコン -->
+  <div class="flex items-center justify-between mt-4">
+    <!-- プレイリストタイトル -->
+    <div>
+      <h3 class="text-lg font-bold text-black">
+        <%= playlist.title %>
+      </h3>
+      <!-- 公開・非公開 -->
+      <p class="text-sm text-gray-500 mt-1">
+        <%= I18n.t("activerecord.attributes.playlist.visibility.#{playlist.visibility}") %>
+      </p>
+    </div>
+    <% end %>
+
+
+    <!-- 三点リーダーアイコンとドロップダウン -->
+    <div class="dropdown dropdown-end">
+      <label tabindex="0" class="btn btn-ghost">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-black" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01" />
+        </svg>
+      </label>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 right-0 bg-white z-10">
+        <li class="flex items-center">
+          <!-- 編集モーダルをトグルするラベル -->
+          <label for="edit-modal-<%= playlist.id %>" class="flex w-full items-center hover:bg-purple-600 hover:text-white text-black rounded">
+            <span>編集</span>
+          </label>
+        </li>
+        <li class="flex items-center">
+          <!-- 削除アイコン -->
+          <%= link_to "削除", playlist_path(playlist), 
+          data: { turbo_method: :delete, turbo_frame: "_top" }, 
+          class: "flex w-full items-center hover:bg-purple-600 hover:text-white text-black rounded" %>
+        </li>
+        <li class="flex items-center">
+          <!-- 共有アイコン -->
+          <a href="#" class="flex w-full items-center hover:bg-purple-600 hover:text-white text-black rounded">
+            <span>共有</span>
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
-<% else %>
-<p>プレイリストはありません</p>
+
+<!-- モーダルの部分テンプレート -->
+<%= render partial: "users/modal", locals: { playlist: playlist } %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,14 +9,18 @@
     </div>
   </div>
 </div>
+
 <div class="mt-8 bg-gray-50 p-6 rounded-lg">
   <h2 class="text-xl font-bold text-black mb-4">マイライブラリ</h2>
+  <!-- プレイリスト一覧 -->
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
     <% @playlists.each do |playlist| %>
-    <%if playlist.present? %>
     <%= render 'playlist', playlist: playlist %>
-    <% else %>
     <% end %>
-    <% end %>
+  </div>
+
+  <!-- ページネーションリンク -->
+  <div data-controller="scroll-to-top" class="pagination-links mt-6 flex justify-center">
+    <%= paginate @playlists %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module TwichClipFinder
     config.load_defaults 7.2
 
     # Railsアプリケーションのデフォルトの言語設定を日本語に設定
-    config.i18n.default_locale = :en
+    config.i18n.default_locale = :ja
 
     # Cookie設定
     config.middleware.use ActionDispatch::Cookies

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,10 @@
 ja:
   activerecord:
+    attributes:
+      playlist:
+        visibility:
+          public: "公開"
+          private: "非公開"
     errors:
       models:
         clip:
@@ -11,4 +16,3 @@ ja:
           required: "クリップは %{attribute} が必要です。"
       messages:
         required: "を入力してください。"
-

--- a/db/migrate/20241210134136_rename_name_to_title_in_playlists.rb
+++ b/db/migrate/20241210134136_rename_name_to_title_in_playlists.rb
@@ -1,0 +1,5 @@
+class RenameNameToTitleInPlaylists < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :playlists, :name, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_29_104043) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_10_134136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,7 +42,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_29_104043) do
     t.index ["user_uid", "clip_id"], name: "index_favorite_clips_on_user_uid_and_clip_id", unique: true
   end
 
-  create_table "games", force: :cascade do |t|
+  create_table "games", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "box_art_url"
     t.datetime "created_at", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_29_104043) do
 
   create_table "playlists", force: :cascade do |t|
     t.string "user_uid", null: false
-    t.string "name", null: false
+    t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "visibility", default: "private", null: false


### PR DESCRIPTION
## 変更の概要

* ユーザープロフィール画面でプレイリスト名と公開設定の変更ができるようにしました
* #112 

## なぜこの変更をするのか

* 現在の状態では、ユーザーはプレイリスト名と公開設定を変更できないため

## やったこと

* [x] やったこと
* [x] `update`アクションの実装
* [x] 編集モーダル画面の実装
* [x] JavaScriptによる入力チェックの実装 
* [x] 編集モーダル画面のデザイン
* [x] playlistテーブルの`name`カラムを`title`カラムに変更 
* [x] 編集・削除・X共有のモーダル表示 

## 変更内容
* 編集モーダル画面
![image](https://github.com/user-attachments/assets/b779bcc0-3b37-40d9-b9ea-fe43a47743f1)
* 三点リーダーによるモーダル画面
![image](https://github.com/user-attachments/assets/4d41384f-2003-4914-9f13-98deef2f69eb)

## どうやるのか

* 三点リーダーを押下
* 編集ボタンを押下
* モーダル画面を表示
