### PR TITLE
プレイリスト内のクリップ削除　実装

### DIFF
--- a/app/controllers/playlist_clips_controller.rb
+++ b/app/controllers/playlist_clips_controller.rb
@@ -54,7 +54,6 @@ class PlaylistClipsController < ApplicationController
     playlist = Playlist.find(params[:id])
     @clip = Clip.find(@clip_id)
     playlist.clips.destroy(@clip)
-    playlist.clips.destroy(@clip)
     if playlist.clips.empty?
       playlist.destroy
       redirect_to playlists_path, notice: "クリップを全て削除したためプロフィール画面へ移動しました", status: :see_other

--- a/app/controllers/playlist_clips_controller.rb
+++ b/app/controllers/playlist_clips_controller.rb
@@ -1,10 +1,8 @@
 class PlaylistClipsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_params
 
   def create
-    # フォームから送信されたデータを取得
-    set_params
-
     # クリップを取得
     clip = Clip.find(@clip_id)
 
@@ -50,6 +48,22 @@ class PlaylistClipsController < ApplicationController
 
     # プレイリストを変数にして渡す
     @playlists = current_user.playlists
+  end
+
+  def destroy
+    playlist = Playlist.find(params[:id])
+    @clip = Clip.find(@clip_id)
+    playlist.clips.destroy(@clip)
+    playlist.clips.destroy(@clip)
+    if playlist.clips.empty?
+      playlist.destroy
+      redirect_to playlists_path, notice: "クリップを全て削除したためプロフィール画面へ移動しました", status: :see_other
+    else
+      respond_to do |format|
+        format.turbo_stream { flash.now[:notice] = "該当のクリップを削除しました" }
+        format.html { redirect_to edit_playlist_path(playlist), notice: "該当のクリップを削除しました", status: :see_other }
+      end
+    end
   end
 
   private

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -8,10 +8,22 @@ class PlaylistsController < ApplicationController
   # 明示的に application レイアウトを使用
   layout "application"
 
+  def index
+    # プレイリストを取得
+    @playlists = current_user.playlists
+    @playlists = @playlists.order(:id)
+    @playlists = Kaminari.paginate_array(@playlists).page(params[:page]).per(9)
+  end
+
+  def edit
+    @playlist = Playlist.find(params[:id])
+    @clips = @playlist.clips.includes(:streamer)
+  end
+
   def show
     # プレイリスト内の全クリップを取得
     @playlist = Playlist.find(params[:id])
-    @clips = @playlist.clips.includes(:streamer).page(params[:page]).per(60)
+    @clips = @playlist.clips.includes(:streamer)
 
     # 再生するクリップを特定（パラメータがなければ最初のクリップを使用）
     @clip = params[:clip_id].present? ? @clips.find_by(id: params[:clip_id]) : @clips.first
@@ -22,7 +34,6 @@ class PlaylistsController < ApplicationController
     @playlist = current_user.playlists.build
   end
 
-  # POST /playlists
   # 新しいプレイリストを作成
   def create
     @playlist = current_user.playlists.build(playlist_params)
@@ -31,10 +42,6 @@ class PlaylistsController < ApplicationController
     else
       render :new
     end
-  end
-
-  # プレイリスト編集フォームを表示
-  def edit
   end
 
   # プレイリストを更新

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,9 +39,5 @@ class UsersController < ApplicationController
 
   # マイページへ
   def show
-    # プレイリストを取得
-    @playlists = current_user.playlists
-    @playlists = @playlists.order(:id)
-    @playlists = Kaminari.paginate_array(@playlists).page(params[:page]).per(9)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
   <link rel="apple-touch-icon" href="/icon.png">
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  <script src="https://kit.fontawesome.com/4025a67f93.js" crossorigin="anonymous"></script>
 </head>
 
 <body class="bg-gray-100 flex flex-col min-h-screen">
@@ -52,7 +53,7 @@
         </div>
       </div>
       <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
-        <li><%= link_to 'プロフィール', show_path(current_user) %></li>
+        <li><%= link_to 'プロフィール', playlists_path %></li>
         <li>
           <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-white-500 no-button-style" %>
         </li>

--- a/app/views/playlist_clips/destroy.turbo_stream.erb
+++ b/app/views/playlist_clips/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.prepend "flash_messages", partial: "layouts/flash_messages" %>
+<%= turbo_stream.remove @clip %>

--- a/app/views/playlists/_clip.html.erb
+++ b/app/views/playlists/_clip.html.erb
@@ -102,7 +102,7 @@
   <div class="modal">
     <div class="modal-box rounded-lg shadow-lg">
       <h3 class="font-bold text-lg">新しいプレイリストを作成</h3>
-      <%= form_with url: playlist_playlist_clip_index_path, method: :post do |f| %>
+      <%= form_with url: playlist_playlist_clip_index_path, method: :post do |f| %>
       <input type="hidden" name="search_query" value="<%= @search_query %>" />
       <div class="form-control mt-4">
         <label class="label">

--- a/app/views/playlists/_clip.html.erb
+++ b/app/views/playlists/_clip.html.erb
@@ -49,7 +49,7 @@
         <!-- モーダル内のコンテンツ -->
         <div class="py-4">
           <!-- プレイリストのチェックボックスリスト -->
-          <%= form_with url: playlist_clips_path, method: :post do |f| %>
+          <%= form_with url: playlist_playlist_clip_index_path, method: :post do |f| %>
           <input type="hidden" name="search_query" value="<%= @search_query %>" />
           <input type="hidden" name="clip_id" value="<%= clip.id %>" />
 
@@ -102,7 +102,7 @@
   <div class="modal">
     <div class="modal-box rounded-lg shadow-lg">
       <h3 class="font-bold text-lg">新しいプレイリストを作成</h3>
-      <%= form_with url: playlist_clips_path, method: :post do |f| %>
+      <%= form_with url: playlist_playlist_clip_index_path, method: :post do |f| %>
       <input type="hidden" name="search_query" value="<%= @search_query %>" />
       <div class="form-control mt-4">
         <label class="label">

--- a/app/views/playlists/_clip_list.html.erb
+++ b/app/views/playlists/_clip_list.html.erb
@@ -1,0 +1,25 @@
+<!-- 動画リスト -->
+<div class="overflow-y-auto flex-grow max-h-[calc(100vh-16rem)]">
+  <ul class="space-y-4">
+    <% @clips.each do |clip| %>
+    <li class="flex items-center bg-gray-100 rounded-lg shadow-md p-4" id="<%= dom_id(clip) %>">
+      <!-- サムネイル -->
+      <div class="w-32 h-20 bg-gray-300 rounded-lg flex-shrink-0">
+        <img src="<%= clip.thumbnail_url %>" alt="<%= clip.title %>" class="w-full h-full object-cover rounded-lg" />
+      </div>
+      <!-- 動画情報 -->
+      <div class="ml-4 flex-1">
+        <h3 class="text-base font-bold text-black"><%= clip.title %></h3>
+        <p class="text-sm text-gray-500"><%= clip.streamer.display_name %> · <%= clip.view_count %>回視聴</p>
+      </div>
+      <!-- ゴミ箱マーク -->
+      <div>
+        <%= button_to playlist_clip_path(@playlist), method: :delete, data: { turbo_frame: "_top" }, class: "btn btn-ghost btn-sm text-error" do %>
+        <i class="fa-solid fa-trash"></i>
+        <%= hidden_field_tag :clip_id, clip.id %>
+        <% end %>
+      </div>
+    </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/playlists/_edit_playlist_clips.html.erb
+++ b/app/views/playlists/_edit_playlist_clips.html.erb
@@ -1,0 +1,33 @@
+<div class="mb-6">
+  <!-- プレイリストタイトルセクション -->
+  <div class="p-4 rounded-lg bg-gray-50">
+    <!-- タイトルと公開・非公開の配置 -->
+    <div class="flex justify-between items-center mb-4">
+      <!-- プレイリストタイトル -->
+      <h2 class="text-3xl font-bold tracking-wide text-black break-words"><%= @playlist.title %></h2>
+      <!-- 公開・非公開 -->
+      <div class="flex items-center space-x-2 text-sm bg-gray-100 p-2 rounded-lg">
+        <% if @playlist.visibility == "private" %>
+        <i class="fa-solid fa-lock text-gray-500"></i>
+        <span class="text-gray-500">非公開</span>
+        <% elsif @playlist.visibility == "public" %>
+        <i class="fa-solid fa-earth-americas text-gray-500"></i>
+        <span class="text-gray-500">公開</span>
+        <% end %>
+      </div>
+    </div>
+    <!-- 編集アイコンと共有アイコン -->
+    <div class="flex items-center space-x-4">
+      <!-- 編集アイコン -->
+      <button class="btn btn-circle btn-outline text-gray-700 hover:bg-purple-700 hover:text-white transition" title="編集">
+        <label for="edit-modal-<%= @playlist.id %>">
+          <i class="fa-regular fa-pen-to-square text-xl"></i>
+        </label>
+      </button>
+      <!-- 共有アイコン -->
+      <button class="btn btn-circle btn-outline text-gray-700 hover:bg-purple-700 hover:text-white transition" title="共有">
+        <i class="fa-brands fa-twitter text-xl"></i>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/views/playlists/_modal.html.erb
+++ b/app/views/playlists/_modal.html.erb
@@ -1,4 +1,5 @@
 <!-- 編集モーダル -->
+<% if playlist.present? %>
 <input type="checkbox" id="edit-modal-<%= playlist.id %>" class="modal-toggle" />
 <div class="modal flex justify-center items-center fixed inset-0 bg-white z-50">
   <div class="modal-box bg-white rounded-lg shadow-lg max-w-md w-full text-black">
@@ -12,15 +13,20 @@
     <div class="p-6 space-y-6" data-controller="form-validation">
       <%= form_with(model: playlist, url: playlist_path(playlist), method: :patch, data: { turbo: false }) do |form| %>
       <!-- プレイリスト画像 -->
-      <%= image_tag playlist.clips.first&.thumbnail_url, alt: "サムネイル", class: "rounded-lg w-full h-32 object-cover" %>
+      <% if playlist.clips.first&.thumbnail_url.present? %>
+      <%= image_tag playlist.clips.first.thumbnail_url, alt: "サムネイル", class: "rounded-lg w-full h-32 object-cover" %>
+      <% else %>
+      <p class="text-gray-500 text-center">サムネイル画像がありません</p>
+      <% end %>
+
       <!-- プレイリスト名 -->
       <div>
         <%= form.label :title, "プレイリスト名", class: "block text-sm font-medium text-black" %>
         <%= form.text_field :title, 
-          value: playlist.title, 
-          class: "mt-1 block w-full bg-white border border-gray-300 rounded-md shadow-sm focus:ring-purple-500 focus:border-purple-500 text-black", 
-          data: { form_validation_target: "input", action: "input->form-validation#validate" }, 
-          required: "required" %>
+            value: playlist.title, 
+            class: "mt-1 block w-full bg-white border border-gray-300 rounded-md shadow-sm focus:ring-purple-500 focus:border-purple-500 text-black", 
+            data: { form_validation_target: "input", action: "input->form-validation#validate" }, 
+            required: "required" %>
         <!-- 必須エラーメッセージ -->
         <div class="text-red-500 text-sm hidden mt-1" data-form-validation-target="errorMessage">
           プレイリスト名を入力してください。
@@ -37,17 +43,17 @@
       <div class="form-control mt-4 bg-white">
         <%= form.label :visibility, "公開設定", class: "label-text block text-sm font-medium text-black" %>
         <%= form.select :visibility, [["非公開", "private"], ["公開", "public"]], 
-        { selected: form.object.visibility }, 
-        class: "select select-bordered bg-white text-black" %>
+            { selected: form.object.visibility }, 
+            class: "select select-bordered bg-white text-black" %>
       </div>
-
       <!-- モーダルフッター内にフォームの送信ボタンを配置 -->
       <div class="flex justify-end space-x-2 mt-4">
         <%= form.submit "変更", 
-    class: "btn bg-purple-600 hover:bg-purple-700 text-white border-none", 
-    data: { action: "form-validation#validate" } %>
+            class: "btn bg-purple-600 hover:bg-purple-700 text-white border-none", 
+            data: { action: "form-validation#validate" } %>
       </div>
       <% end %>
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/playlists/_playlist.html.erb
+++ b/app/views/playlists/_playlist.html.erb
@@ -37,8 +37,7 @@
       <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52 right-0 bg-white z-10">
         <li class="flex items-center">
           <!-- 編集モーダルをトグルするラベル -->
-          <label for="edit-modal-<%= playlist.id %>" class="flex w-full items-center hover:bg-purple-600 hover:text-white text-black rounded">
-            <span>編集</span>
+          <%= link_to "編集", edit_playlist_path(playlist), class: "flex w-full items-center hover:bg-purple-600 hover:text-white text-black rounded" %>
           </label>
         </li>
         <li class="flex items-center">
@@ -59,5 +58,5 @@
 </div>
 
 <!-- モーダルの部分テンプレート -->
-<%= render partial: "users/modal", locals: { playlist: playlist } %>
+<%= render partial: "modal", locals: { playlist: playlist } %>
 <% end %>

--- a/app/views/playlists/edit.html.erb
+++ b/app/views/playlists/edit.html.erb
@@ -1,0 +1,27 @@
+<div class="bg-white text-base-content p-6 rounded-lg max-w-[calc(100%-4cm)] mx-auto min-h-screen shadow flex flex-col">
+  <!-- ヘッダー -->
+  <div class="flex items-center mb-6">
+    <!-- プロフィール画像とユーザー名 -->
+    <div class="flex items-center">
+      <!-- プロフィール画像 -->
+      <div class="w-12 h-12 rounded-full overflow-hidden bg-gray-300">
+        <img src="<%= current_user.profile_image_url %>" alt="<%= current_user.user_name %>" class="w-full h-full object-cover" />
+      </div>
+      <!-- ユーザー名 -->
+      <div class="ml-4">
+        <h1 class="text-lg font-bold text-black"><%= current_user.user_name %></h1>
+      </div>
+    </div>
+  </div>
+
+  <!-- プレイリストのクリップ編集 -->
+  <% if @playlist.present? %>
+  <%= render partial: "edit_playlist_clips", locals: { playlist: @playlist } %>
+
+  <!-- クリップリスト -->
+  <%= render partial: "clip_list", locals: { clips: @clips, playlist: @playlist } %>
+
+  <!-- モーダル画面 -->
+  <%= render partial: "modal", locals: { playlist: @playlist } %>
+  <% end %>
+</div>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,18 +1,26 @@
-<h1>マイプレイリスト</h1>
-
-<%= link_to "新しいプレイリストを作成", new_playlist_path, class: "bg-green-500 text-white px-4 py-2 rounded" %>
-
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-4">
-  <% @playlists.each do |playlist| %>
-    <div class="bg-gray-700 p-4 rounded-lg shadow-md hover:shadow-lg transition-shadow">
-      <h3 class="text-lg font-bold text-purple-300">
-        <%= link_to playlist.name, playlist_path(playlist), class: "hover:underline" %>
-      </h3>
-      <p class="text-gray-400 text-sm mt-2">クリップ数: <%= playlist.clips.count %></p>
-      <div class="mt-4 flex items-center justify-between">
-        <span class="text-sm text-gray-500">いいね: <%= playlist.likes %></span>
-        <%= link_to "編集", edit_playlist_path(playlist), class: "text-sm bg-blue-500 text-white py-1 px-3 rounded hover:bg-blue-600" %>
-      </div>
+<div class="bg-white p-4 rounded-lg shadow-md">
+  <!-- ユーザープロフィール -->
+  <div class="flex items-center mb-6">
+    <div class="w-12 rounded-full">
+      <%= image_tag(current_user.profile_image_url, alt: "プロフィール画像", class: "profile-image", width: "50", height: "50") if current_user.profile_image_url.present? %>
     </div>
-  <% end %>
+    <div class="ml-4">
+      <h2 class="text-xl font-bold"><%= current_user.user_name %></h2>
+    </div>
+  </div>
+</div>
+
+<div class="mt-8 bg-gray-50 p-6 rounded-lg">
+  <h2 class="text-xl font-bold text-black mb-4">マイライブラリ</h2>
+  <!-- プレイリスト一覧 -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% @playlists.each do |playlist| %>
+    <%= render 'playlist', playlist: playlist %>
+    <% end %>
+  </div>
+
+  <!-- ページネーションリンク -->
+  <div data-controller="scroll-to-top" class="pagination-links mt-6 flex justify-center">
+    <%= paginate @playlists %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   get "search", to: "search#index"
 
   # プレイリストクリップ用ルート
-  resources :playlist_clips, only: [ :create ]
+  resources :playlist_clips
 
   # プレイリストのルート
   resources :playlists
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # 認証をハードコード
+  # Sidekiq認証
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     username == ENV["SIDEKIQ_USERNAME"] && password == ENV["SIDEKIQ_PASSWORD"]
   end


### PR DESCRIPTION
## 変更の概要
ユーザーが自分自身で作成したクリップを削除できるようにする
#90 

## なぜこの変更をするのか
* 現在のアプリの機能では、ユーザーが作成した個々のクリップを削除できる機能がないため

## やったこと

* [x] やったこと
* [x] プレイリスト編集画面の作成
* [x] プレイリスト内のクリップ削除機能

## 変更内容
![image](https://github.com/user-attachments/assets/9ca1d17d-6434-4500-8d45-766f01739d17)


## 影響範囲

* ユーザーに影響すること
* プレイリスト内のクリップ編集画面、クリップ削除機能の実装
* メンバーに影響すること
* `PlaylistClipController`の`destroy`アクションの追加

## どうやるのか

* 使い方
* 再現手順
* ユーザープロフィール画面から三点リーダーを押下し、「編集ボタン」を押下
* プレイリスト内のクリップ編集画面にいき、クリップの横のゴミ箱マークを押下